### PR TITLE
Made the tabpanels looks as COH expects.

### DIFF
--- a/elements/Tabs.inc
+++ b/elements/Tabs.inc
@@ -51,7 +51,7 @@ class Tabs {
  * 
  * @param array $vars 
  */
-function xml_form_elements_preprocess_tabs(&$vars) {
+function xml_form_elements_preprocess_tabs_content(&$vars) {
   $tabs = $vars['tabs'];
   // Header Info
   $vars['collapsible'] = $tabs['#collapsible'] == TRUE;
@@ -87,3 +87,10 @@ function xml_form_elements_preprocess_tabs(&$vars) {
   }
 }
 
+/**
+ * Theme Hook for tags elements.
+ */
+function xml_form_elements_theme_tabs($element) {
+  $content = theme('tabs_content', $element);
+  return theme('form_element', $element, $content);
+}

--- a/elements/Tabs.tpl.php
+++ b/elements/Tabs.tpl.php
@@ -15,7 +15,7 @@ $classes .= ( $collapsed) ? 'xml-form-elements-tabs-collapsed' : '';
           <span class='expand-tabpanel-icon ui-icon ui-icon-circle-triangle-s' style='float: right; vertical-align: middle; margin-left:0.2em;'></span>
         <?php endif; ?>
       </a>
-      <span class="tool_tip"></span>
+      <span class="tool_tip">Empty</span>
     </li>
     <!-- All other Tab Panels -->
     <?php if (isset($tabpanels)): ?>
@@ -28,9 +28,7 @@ $classes .= ( $collapsed) ? 'xml-form-elements-tabs-collapsed' : '';
           <?php if ($remove_button !== FALSE): ?>
             <span class='ui-icon ui-icon-close' style='float: left; margin: 0.4em 0.2em 0 0; cursor: pointer;'><?php print $remove_button ?></span>
           <?php endif ?>
-          <span class="tool_tip">
-              Testing !
-          </span>
+          <span class="tool_tip">Empty</span>
         </li>
       <?php endforeach; ?>
     <?php endif; ?>

--- a/elements/Tabs.tpl.php
+++ b/elements/Tabs.tpl.php
@@ -8,16 +8,14 @@ $classes .= ( $collapsed) ? 'xml-form-elements-tabs-collapsed' : '';
     <!-- First Tab Panel -->
     <li class='tool_tip_trigger'>
       <a href='<?php print "#$link" ?>'>
-        <span style='float:left; vertical-align: middle; text-align: center;'><?php print $title ?></span>
+        <span style='float:left; vertical-align: middle; text-align: center;'><?php print '1'; ?></span>
         <?php if ($collapsible): ?>
           <span class='expand-tabpanel-icon ui-icon ui-icon-circle-triangle-e' style='float: right; vertical-align: middle; margin-left:0.2em;'></span>
         <?php else: ?>
           <span class='expand-tabpanel-icon ui-icon ui-icon-circle-triangle-s' style='float: right; vertical-align: middle; margin-left:0.2em;'></span>
         <?php endif; ?>
       </a>
-      <span class="tool_tip">
-          Testing one!
-      </span>
+      <span class="tool_tip"></span>
     </li>
     <!-- All other Tab Panels -->
     <?php if (isset($tabpanels)): ?>

--- a/elements/js/Tabs.js
+++ b/elements/js/Tabs.js
@@ -65,7 +65,7 @@ xml_form_elements.tabpanel = {
         var id = $(this).children('a[href]').attr('href');
         $('#' + id + ' div.form-item').each(function() {
           var item = $(this);
-          var text = $('input[class~="form-text"]', item);
+          var text = $('input[type~="text"]', item);
           if(text.length) {
             var id = text.attr('id');
             var label = $('label[for=' + id + ']', item);

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -52,6 +52,11 @@ function xml_form_elements_theme() {
   return array(
     'tabs' => array(
       'arguments' => array('tabs' => NULL),
+      'file' => 'Tabs.inc',
+      'function' => 'xml_form_elements_theme_tabs'
+    ),
+    'tabs_content' => array( // The inner content of a tabs element.
+      'arguments' => array('tabs' => NULL),
       'template' => 'Tabs',
       'file' => 'Tabs.inc'
     ),


### PR DESCRIPTION
COH has made the recommendation that tab panels look more like regular Drupal form elements.
With the title appearing in bold before the element. This moves the title from the first tab to be more like the Drupal style.
