### PR TITLE
Change so that all duplicated fields default values are empty

### DIFF
--- a/elements/includes/Element.inc
+++ b/elements/includes/Element.inc
@@ -97,6 +97,7 @@ class Element {
     $form = new XMLForm($form_state);
     $original = $form->findElement($duplicate);
     $new_element = $form->duplicateOriginal($duplicate);
+    $new_element->eachDecendant('Element::removeDefault');
     $original->parent->adopt($new_element);
     $drupal_form = Ahah::rebuildForm($form_id, $form_build_id, $drupal_form, $form_state);
     // Find the element to render.
@@ -104,6 +105,15 @@ class Element {
     $element = find_element($drupal_form, $render);
     // Respond to the request with JSON.
     Ahah::respond($element);
+  }
+
+  /**
+    * Used by the duplicate function to clear default values of descendants
+    * 
+    * @param type $child 
+    */
+  public static function removeDefault($child) {
+     $child->default_value = '';
   }
 
   /**


### PR DESCRIPTION
Fix for default values being carried over on duplication.
