### PR TITLE
Form now only validates/populates the values for the ajax field which tr...

### DIFF
--- a/elements/includes/TabPanel.inc
+++ b/elements/includes/TabPanel.inc
@@ -60,7 +60,7 @@ class TabPanel {
    * @param FormElement $tabpanel
    * @return FormElement
    */
-  private static function createAddButton(array &$element, array & $complete_form, $label) {
+  private static function createAddButton(array &$element, array &$complete_form, $label) {
     $tabs = get_form_element_parent($element, $complete_form);
     $add['#type'] = 'button';
     $add['#weight'] = 4;
@@ -69,6 +69,7 @@ class TabPanel {
     $add['#value'] = $label;
     $add['#prefix'] = '<div class="ui-tabpanel-add-button">';
     $add['#suffix'] = '</div>';
+    $add['#limit_validation_errors'][] = $element['#parents'];
     $add['#ajax'] = array(
       'params' => array(
       	'target' => $tabs['#hash'],
@@ -102,6 +103,7 @@ class TabPanel {
     );
     $delete['#prefix'] = '<div class="ui-tabpanel-delete-button">';
     $delete['#suffix'] = '</div>';
+    $delete['#limit_validation_errors'][] = $element['#parents'];
     $delete['#ajax'] = array(
       'callback' => 'xml_form_elements_ajax_callback',
       'params' => array(

--- a/elements/includes/Tags.inc
+++ b/elements/includes/Tags.inc
@@ -73,6 +73,7 @@ class Tags {
     $button['#id'] = $button['#name'] = $element['#hash'] . '-add';
     $button['#attributes'] = array('style' => 'display:none');
     $button['#value'] = t('Add');
+    $button['#limit_validation_errors'][] = $element['#parents'];
     $button['#ajax'] = array(
       'callback' => 'xml_form_elements_ajax_callback',
       'params' => array(
@@ -93,6 +94,7 @@ class Tags {
     $button['#size'] = 30;
     $button['#id'] = $button['#name'] = $child['#hash'] . '-remove';
     $button['#attributes'] = array('style' => 'display:none');
+    $button['#limit_validation_errors'][] = $element['#parents'];
     $button['#ajax'] = array(
       'callback' => 'xml_form_elements_ajax_callback',
       'params' => array(
@@ -114,6 +116,7 @@ class Tags {
     $button['#size'] = 30;
     $button['#id'] = $button['#name'] = $child['#hash'] . '-edit';
     $button['#attributes'] = array('style' => 'display:none');
+    $button['#limit_validation_errors'][] = $element['#parents'];
     $button['#ajax'] = array(
       'callback' => 'xml_form_elements_ajax_callback',
       'params' => array(

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -235,8 +235,8 @@ function xml_form_elements_form_element_tabs_ajax_add(FormElement $element, arra
 function xml_form_elements_form_element_tabs_ajax_delete(FormElement $element, array &$form, array &$form_state) {
   $tab = $element->findElement($form_state['triggering_element']['#ajax']['params']['child']);
   $tab->orphan();
-  foreach(element_children($form) as $child) {
-    if($form[$child]['#hash'] == $tab->hash) {
+  foreach (element_children($form) as $child) {
+    if ($form[$child]['#hash'] == $tab->hash) {
       unset($form[$child]);
       break;
     }
@@ -264,7 +264,7 @@ function xml_form_elements_form_element_tags_ajax_alter(FormElement $element, ar
 
 function xml_form_elements_form_element_tags_ajax_add(FormElement $element, array &$form, array &$form_state) {
   $input_field = &$form[array_shift(element_children($form))];
-  $default_value =  $input_field['#default_value']; // Get Input Value as its not stored in the object form.
+  $default_value = $input_field['#default_value']; // Get Input Value as its not stored in the object form.
   $input_field['#value'] = '';
   $input = array_shift(array_values($element->children));
   $tag = clone $input;
@@ -279,8 +279,8 @@ function xml_form_elements_form_element_tags_ajax_delete(FormElement $element, a
   $hash = $triggering_element['#ajax']['params']['child'];
   $tag = $element->findElement($hash);
   $tag->orphan();
-  foreach(element_children($form) as $child) {
-    if($form[$child]['#hash'] == $hash) {
+  foreach (element_children($form) as $child) {
+    if ($form[$child]['#hash'] == $hash) {
       unset($form[$child]);
     }
   }
@@ -289,7 +289,7 @@ function xml_form_elements_form_element_tags_ajax_delete(FormElement $element, a
 function xml_form_elements_form_element_tags_ajax_edit(FormElement $element, array &$form, array &$form_state) {
   $triggering_element = $form_state['triggering_element'];
   $input_field = &$form[array_shift(element_children($form))];
-  if($input_field['#default_value'] != '') {
+  if ($input_field['#default_value'] != '') {
     xml_form_elements_form_element_tags_ajax_add($element, $form, $form_state);
   }
   $hash = $triggering_element['#ajax']['params']['child'];


### PR DESCRIPTION
Form now only validates/populates the values for the ajax field which triggers the callback. Prevents validation errors on fields unrelated to the ajax callback.
