### PR TITLE
js calls to forEach removed, replaced with Ext.Array.each

### DIFF
--- a/builder/js/Formbuilder.js
+++ b/builder/js/Formbuilder.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
@@ -74,7 +74,7 @@ Ext.formbuilder = (function() {
       if(record.data['namespaces'] instanceof Object) {
         jQuery.each(record.data['namespaces'], function(i, n) {
           namespaces.push({
-            key: i, 
+            key: i,
             value: n
           });
         });
@@ -109,7 +109,7 @@ Ext.formbuilder = (function() {
           });
           return output;
         }
-        form_array_grids.forEach(function(name) {
+        Ext.Array.each(form_array_grids, function(name) {
           var store = Ext.getCmp(name).store;
           record.set(name, toArray(store));
         });
@@ -123,7 +123,7 @@ Ext.formbuilder = (function() {
           });
           return output;
         }
-        form_map_grids.forEach(function(name) {
+        Ext.Array.each(form_map_grids, function(name) {
           var store = Ext.getCmp(name).store;
           record.set(name, toObject(store));
         });

--- a/builder/js/TreePanel.js
+++ b/builder/js/TreePanel.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
@@ -97,12 +97,12 @@ Ext.formbuilder.createTreePanel = function() {
           form.loadRecord(record);
           //attributes
           var form_grids = [ 'attributes', 'element_validate', 'process', 'pre_render', 'post_render', 'after_build', 'options', 'user_data', 'submit', 'validate'];
-          form_grids.forEach(function(name) {
+          Ext.Array.each(form_grids, function(name) {
             var converted = [];
             if(data[name] instanceof Object) {
               jQuery.each(data[name], function(i, n) {
                 converted.push({
-                  key: i, 
+                  key: i,
                   value: n
                 });
               });
@@ -206,10 +206,9 @@ Ext.formbuilder.createTreePanel = function() {
             Ext.getCmp('actions_update').collapse();
             Ext.getCmp('actions_delete').collapse();
           }
-                    
+
         }
       }
     }
   });
 }
-


### PR DESCRIPTION
Form builder was not allowing users to change selected form elements in IE7/IE8 
IE didn't support the JS array object function forEach.
