### PR TITLE
Add Drupal.t() to interface strings in form builder.

### DIFF
--- a/builder/js/EditForm.js
+++ b/builder/js/EditForm.js
@@ -698,7 +698,7 @@ Ext.app = (function() {
         },
         createFormPreview: function() { // Use an iframe...
             var view_url = url.replace(/\/edit/i, '/view');
-            var preview = "<iframe src='" + view_url + "' width='100%' height='100%'><p>Your browser does not support iframes.</p></iframe>";
+            var preview = "<iframe src='" + view_url + "' width='100%' height='100%'><p>" + Drupal.t('Your browser does not support iframes.') + "</p></iframe>";
             return Ext.create('Ext.form.Panel', {
                 title: Drupal.t('Preview'),
                 html: preview

--- a/builder/js/EditForm.js
+++ b/builder/js/EditForm.js
@@ -140,7 +140,7 @@ Ext.app = (function() {
                 margin: '1 1 1 0',
                 items: [{
                     xtype: 'fieldset',
-                    title: 'Common Form Controls',
+                    title: Drupal.t('Common Form Controls'),
                     collapsible: true,
                     items: [{
                         xtype: 'textfield',

--- a/builder/js/ElementForm.js
+++ b/builder/js/ElementForm.js
@@ -24,7 +24,7 @@ Ext.formbuilder.createElementForm = function () {
           Ext.create('Ext.tip.ToolTip', {
             target: 'key',
             anchor: 'left',
-            html: 'Identifies this form element. It is used as the drupal form array key for this element.'
+            html: Drupal.t('Identifies this form element. It is used as the drupal form array key for this element.')
           });
         }
       }

--- a/builder/js/ElementForm.js
+++ b/builder/js/ElementForm.js
@@ -17,7 +17,7 @@ Ext.formbuilder.createElementForm = function () {
       xtype: 'textfield',
       id: 'key',
       name: 'key',
-      fieldLabel: 'Identifier',
+      fieldLabel: Drupal.t('Identifier'),
       width: 640,
       listeners: {
         render: function() {
@@ -48,7 +48,7 @@ Ext.formbuilder.createElementForm = function () {
           store: this.elementTypeStore,
           displayField: 'display',
           valueField: 'value',
-          fieldLabel: 'Type',
+          fieldLabel: Drupal.t('Type'),
           queryMode: 'local',
           editable: false,
 	  allowBlank: false,
@@ -899,7 +899,7 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'checkbox',
           id: 'executes_submit_callback',
           name: 'executes_submit_callback',
-          fieldLabel: 'Executes Submit Callback',
+          fieldLabel: Drupal.t('Executes Submit Callback'),
           inputValue: true,
           listeners: {
             render: function() {
@@ -964,7 +964,7 @@ Ext.formbuilder.createElementForm = function () {
             xtype: 'textfield',
             id: 'ahah-effect',
             name: 'ahah_effect',
-            fieldLabel: 'Effect',
+            fieldLabel: Drupal.t('Effect'),
             listeners: {
               render: function() {
                 Ext.create('Ext.tip.ToolTip', {

--- a/builder/js/ElementForm.js
+++ b/builder/js/ElementForm.js
@@ -9,7 +9,7 @@
 Ext.formbuilder.createElementForm = function () {
   return Ext.create('Ext.form.Panel', {
     id: 'xml-form-builder-element-form',
-    title: 'Element Form',
+    title: Drupal.t('Element Form'),
     region: 'center',
     frame: true,
     margin: '1 1 1 0',
@@ -38,7 +38,7 @@ Ext.formbuilder.createElementForm = function () {
         frame: true
       },
       items:[{
-        title: 'Common Form Controls',
+        title: Drupal.t('Common Form Controls'),
         collapsible: true,
         autoScroll: true,
         items: [{
@@ -57,9 +57,9 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'type',
                 anchor: 'left',
-                html: '<h3><a name="type" id="type"></a>#type</h3>'+
+                html: Drupal.t('<h3><a name="type" id="type"></a>#type</h3>'+
               '<p><strong>Used by</strong>: All</p>' +
-              '<p><strong>Description</strong>: Used to determine the type of form element.</p>'
+              '<p><strong>Description</strong>: Used to determine the type of form element.</p>')
               });
             }
           }
@@ -67,16 +67,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textfield',
           id: 'title',
           name: 'title',
-          fieldLabel: 'Title',
+          fieldLabel: Drupal.t('Title'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'title',
                 anchor: 'left',
-                html: '<h3><a name="title" id="title"></a>#title</h3>' +
+                html: Drupal.t('<h3><a name="title" id="title"></a>#title</h3>' +
               '<p><strong>Used by</strong>: <a href="#checkbox">checkbox</a>, <a href="#checkboxes">checkboxes</a>, <a href="#date">date</a>, <a href="#fieldset">fieldset</a>, <a href="#file">file</a>, <a href="#item">item</a>, <a href="#password">password</a>, <a href="#password_confirm">password_confirm</a>, <a href="#radio">radio</a>, <a href="#radios">radios</a>, <a href="#select">select</a>, <a href="#textarea">textarea</a>, <a href="#textfield">textfield</a>, <a href="#weight">weight</a></p>' +
               '<p><strong>Description</strong>: The title of the form element.</p>' +
-              '<p><strong>Values</strong>: Mixed</p>'
+              '<p><strong>Values</strong>: Mixed</p>')
               });
             }
           }
@@ -84,17 +84,17 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textarea',
           id: 'description',
           name: 'description',
-          fieldLabel: 'Description',
+          fieldLabel: Drupal.t('Description'),
           width: 500,
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'description',
                 anchor: 'left',
-                html: '<h3><a name="description" id="description"></a>#description</h3>' +
+                html: Drupal.t('<h3><a name="description" id="description"></a>#description</h3>' +
               '<p><strong>Used by</strong>: <a href="#checkbox">checkbox</a>, <a href="#checkboxes">checkboxes</a>, <a href="#date">date</a>, <a href="#fieldset">fieldset</a>, <a href="#file">file</a>, <a href="#item">item</a>, <a href="#password">password</a>, <a href="#password_confirm">password_confirm</a>, <a href="#radio">radio</a>, <a href="#radios">radios</a>, <a href="#select">select</a>, <a href="#textarea">textarea</a>, <a href="#textfield">textfield</a>, <a href="#weight">weight</a></p>' +
               '<p><strong>Description</strong>: The description of the form element. Make sure to enclose inside the <a href="http://api.drupal.org/api/function/t">t</a>() function so this property can be translated.</p>' +
-              '<p><strong>Values</strong>: Mixed</p>'
+              '<p><strong>Values</strong>: Mixed</p>')
               });
             }
           }
@@ -102,16 +102,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textfield',
           id: 'default_value',
           name: 'default_value',
-          fieldLabel: 'Default Value',
+          fieldLabel: Drupal.t('Default Value'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'default_value',
                 anchor: 'left',
-                html: '<h3><a name="default_value" id="default_value"></a>#default_value</h3>' +
+                html: Drupal.t('<h3><a name="default_value" id="default_value"></a>#default_value</h3>' +
               '<p><strong>Used by</strong>: <a href="#checkbox">checkbox</a>, <a href="#checkboxes">checkboxes</a>, <a href="#date">date</a>, <a href="#hidden">hidden</a>, <a href="#radio">radio</a>, <a href="#radios">radios</a>, <a href="#select">select</a>, <a href="#textarea">textarea</a>, <a href="#textfield">textfield</a>, <a href="#token">token</a>, <a href="#weight">weight</a></p>' +
               '<p><strong>Description</strong>: The value of the form element that will be displayed or selected initially if the form has not been submitted yet. <strong>Should NOT be confused with</strong> <strong><a href="#value">#value</a></strong>, which is a hard-coded value the user cannot change!</p>' +
-              '<p><strong>Values</strong>: Mixed</p>'
+              '<p><strong>Values</strong>: Mixed</p>')
               });
             }
           }
@@ -119,17 +119,17 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'checkbox',
           id: 'required',
           name: 'required',
-          fieldLabel: 'Required',
+          fieldLabel: Drupal.t('Required'),
           inputValue: true,
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'required',
                 anchor: 'left',
-                html: '<h3><a name="required" id="required"></a>#required</h3>' +
+                html: Drupal.t('<h3><a name="required" id="required"></a>#required</h3>' +
               '<p><strong>Used by</strong>: <a href="#checkbox">checkbox</a>, <a href="#checkboxes">checkboxes</a>, <a href="#date">date</a>, <a href="#file">file</a>, <a href="#password">password</a>, <a href="#password_confirm">password_confirm</a>, <a href="#radio">radio</a>, <a href="#radios">radios</a>, <a href="#select">select</a>, <a href="#textarea">textarea</a>, <a href="#textfield">textfield</a>, <a href="#weight">weight</a></p>' +
               '<p><strong>Description</strong>: Indicates whether or not the element is required. This automatically validates for empty fields, and flags inputs as required. File fields are <strong>NOT</strong> allowed to be required.</p>' +
-              '<p><strong>Values</strong>: TRUE or FALSE</p>'
+              '<p><strong>Values</strong>: TRUE or FALSE</p>')
               });
             }
           }
@@ -137,12 +137,12 @@ Ext.formbuilder.createElementForm = function () {
           xtype:'fieldset',
           checkboxToggle: true,
           collapsed: true,
-          title:'Create',
+          title: Drupal.t('Create'),
           id: 'actions_create',
           checkboxName: 'actions_create',
           items: [{
             xtype: 'combobox',
-            fieldLabel: 'Path Context',
+            fieldLabel: Drupal.t('Path Context'),
             displayField: 'display',
             valueField: 'value',
             editable: false,
@@ -173,14 +173,14 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'actions-create-context',
                   anchor: 'left',
-                  html: '<h3>Create - Context</h3>' +
-                '<p class="help">The context in which the path will be executed in.</p>'
+                  html: Drupal.t('<h3>Create - Context</h3>' +
+                '<p class="help">The context in which the path will be executed in.</p>')
                 });
               }
             }
           }, {
             xtype: 'textfield',
-            fieldLabel: 'Path',
+            fieldLabel: Drupal.t('Path'),
             name: 'actions_create_path',
             id: 'actions-create-path',
             width: 600,
@@ -189,14 +189,14 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'actions-create-path',
                   anchor: 'left',
-                  html: '<h3>Create - Path</h3>' +
-                '<p class="help">An xpath to this element\'s parent element. This is used to detemine where this element will be inserted.</p>'
+                  html: Drupal.t('<h3>Create - Path</h3>' +
+                '<p class="help">An xpath to this element\'s parent element. This is used to detemine where this element will be inserted.</p>')
                 });
               }
             }
           }, {
             xtype: 'textfield',
-            fieldLabel: 'Schema',
+            fieldLabel: Drupal.t('Schema'),
             name: 'actions_create_schema',
             id: 'actions-create-schema',
             width: 600,
@@ -205,14 +205,14 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'actions-create-schema',
                   anchor: 'left',
-                  html: '<h3>Create - Schema</h3>' +
-                '<p class="help">An xpath to the definition of this element\'s parent. The xpath is executed in the schema defined in this form\'s properties. This is used to determine the insert order for this element.</p>'
+                  html: Drupal.t('<h3>Create - Schema</h3>' +
+                '<p class="help">An xpath to the definition of this element\'s parent. The xpath is executed in the schema defined in this form\'s properties. This is used to determine the insert order for this element.</p>')
                 });
               }
             }
           }, {
             xtype: 'combobox',
-            fieldLabel: 'Type',
+            fieldLabel: Drupal.t('Type'),
             displayField: 'display',
             valueField: 'value',
             editable: false,
@@ -247,14 +247,14 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'actions-create-type',
                   anchor: 'left',
-                  html: '<h3>Create - Type</h3>' +
-                '<p class="help">The type of node that will be created. If XML is specified, an xml snipped is expected in the value field.</p>'
+                  html: Drupal.t('<h3>Create - Type</h3>' +
+                '<p class="help">The type of node that will be created. If XML is specified, an xml snipped is expected in the value field.</p>')
                 });
               }
             }
           }, {
             xtype: 'textarea',
-            fieldLabel: 'Value',
+            fieldLabel: Drupal.t('Value'),
             name: 'actions_create_value',
             id: 'actions-create-value',
             width: 600,
@@ -263,8 +263,8 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'actions-create-value',
                   anchor: 'left',
-                  html: '<h3>Create - Value</h3>' +
-                '<p class="help">If the type is either Element or Attribute, the name of the element or attribute is expected. If the type is XML, an XML snippet is expected where the value of the form field will be inserted where ever the string %value% is used in the xml snippet.</p>'
+                  html: Drupal.t('<h3>Create - Value</h3>' +
+                '<p class="help">If the type is either Element or Attribute, the name of the element or attribute is expected. If the type is XML, an XML snippet is expected where the value of the form field will be inserted where ever the string %value% is used in the xml snippet.</p>')
                 });
               }
             }
@@ -273,12 +273,12 @@ Ext.formbuilder.createElementForm = function () {
           xtype:'fieldset',
           checkboxToggle: true,
           collapsed: true,
-          title:'Read',
+          title: Drupal.t('Read'),
           id: 'actions_read',
           checkboxName: 'actions_read',
           items: [{
             xtype: 'combobox',
-            fieldLabel: 'Path Context',
+            fieldLabel: Drupal.t('Path Context'),
             displayField: 'display',
             valueField: 'value',
             editable: false,
@@ -309,14 +309,14 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'actions-read-context',
                   anchor: 'left',
-                  html: '<h3>Read - Context</h3>' +
-                '<p class="help">The context in which the path will be executed in.</p>'
+                  html: Drupal.t('<h3>Read - Context</h3>' +
+                '<p class="help">The context in which the path will be executed in.</p>')
                 });
               }
             }
           }, {
             xtype: 'textfield',
-            fieldLabel: 'Path',
+            fieldLabel: Drupal.t('Path'),
             name: 'actions_read_path',
             id: 'actions-read-path',
             width: 600,
@@ -325,8 +325,8 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'actions-read-path',
                   anchor: 'left',
-                  html: '<h3>Read - Path</h3>' +
-                '<p class="help">The xpath to the node this form field repersents. The nodes value will be used to auto populate this form field. The node selected by this xpath can be used as the self context for the update and delete actions.</p>'
+                  html: Drupal.t('<h3>Read - Path</h3>' +
+                '<p class="help">The xpath to the node this form field repersents. The nodes value will be used to auto populate this form field. The node selected by this xpath can be used as the self context for the update and delete actions.</p>')
                 });
               }
             }
@@ -335,12 +335,12 @@ Ext.formbuilder.createElementForm = function () {
           xtype:'fieldset',
           checkboxToggle: true,
           collapsed: true,
-          title:'Update',
+          title: Drupal.t('Update'),
           id: 'actions_update',
           checkboxName: 'actions_update',
           items: [{
             xtype: 'combobox',
-            fieldLabel: 'Path Context',
+            fieldLabel: Drupal.t('Path Context'),
             displayField: 'display',
             valueField: 'value',
             editable: false,
@@ -374,14 +374,14 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'actions-update-context',
                   anchor: 'left',
-                  html: '<h3>Update - Context</h3>' +
-                '<p class="help">The context in which the path will be executed in.</p>'
+                  html: Drupal.t('<h3>Update - Context</h3>' +
+                '<p class="help">The context in which the path will be executed in.</p>')
                 });
               }
             }
           }, {
             xtype: 'textfield',
-            fieldLabel: 'Path',
+            fieldLabel: Drupal.t('Path'),
             value: 'self::node()',
             name: 'actions_update_path',
             id: 'actions-update-path',
@@ -391,14 +391,14 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'actions-update-path',
                   anchor: 'left',
-                  html: '<h3>Update - Path</h3>' +
-                '<p class="help">An xpath used to select one or more existing nodes within the document to update. The selected nodes values will be replaced by the value in the this form field.</p>'
+                  html: Drupal.t('<h3>Update - Path</h3>' +
+                '<p class="help">An xpath used to select one or more existing nodes within the document to update. The selected nodes values will be replaced by the value in the this form field.</p>')
                 });
               }
             }
           }, {
             xtype: 'textfield',
-            fieldLabel: 'Schema',
+            fieldLabel: Drupal.t('Schema'),
             name: 'actions_update_schema',
             id: 'actions-update-schema',
             width: 600,
@@ -407,8 +407,8 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'actions-update-schema',
                   anchor: 'left',
-                  html: '<h3>Update - Schema</h3>' +
-                '<p class="help">An xpath to the definition of this element. The xpath is executed in the schema defined in this form\'s properties. This is used to automatically validate submitted values for this form field.</p>'
+                  html: Drupal.t('<h3>Update - Schema</h3>' +
+                '<p class="help">An xpath to the definition of this element. The xpath is executed in the schema defined in this form\'s properties. This is used to automatically validate submitted values for this form field.</p>')
                 });
               }
             }
@@ -417,12 +417,12 @@ Ext.formbuilder.createElementForm = function () {
           xtype:'fieldset',
           checkboxToggle: true,
           collapsed: true,
-          title:'Delete',
+          title: Drupal.t('Delete'),
           id: 'actions_delete',
           checkboxName: 'actions_delete',
           items: [{
             xtype: 'combobox',
-            fieldLabel: 'Path Context',
+            fieldLabel: Drupal.t('Path Context'),
             displayField: 'display',
             valueField: 'value',
             editable: false,
@@ -456,14 +456,14 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'actions-delete-context',
                   anchor: 'left',
-                  html: '<h3>Delete - Context</h3>' +
-                '<p class="help">The context in which the path will be executed in.</p>'
+                  html: Drupal.t('<h3>Delete - Context</h3>' +
+                '<p class="help">The context in which the path will be executed in.</p>')
                 });
               }
             }
           }, {
             xtype: 'textfield',
-            fieldLabel: 'Path',
+            fieldLabel: Drupal.t('Path'),
             value: 'self::node()',
             name: 'actions_delete_path',
             id: 'actions-delete-path',
@@ -473,21 +473,21 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'actions-delete-path',
                   anchor: 'left',
-                  html: '<h3>Delete - Path</h3>' +
-                '<p class="help">An xpath used to select one or more existing nodes within the document to delete. The selected nodes will be removed from the document.</p>'
+                  html: Drupal.t('<h3>Delete - Path</h3>' +
+                '<p class="help">An xpath used to select one or more existing nodes within the document to delete. The selected nodes will be removed from the document.</p>')
                 });
               }
             }
           }]
         }]
       }, {
-        title: 'Advanced Form Controls',
+        title: Drupal.t('Advanced Form Controls'),
         autoScroll: true,
         items: [{
           xtype: 'checkbox',
           id: 'access',
           name: 'access',
-          fieldLabel: 'Access',
+          fieldLabel: Drupal.t('Access'),
           checked: true,
           inputValue: true,
           listeners: {
@@ -495,10 +495,10 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'access',
                 anchor: 'left',
-                html:  '<h3><a name="access" id="access"></a>#access</h3>' +
+                html:  Drupal.t('<h3><a name="access" id="access"></a>#access</h3>' +
               '<p><strong>Used by</strong>: All elements and forms</p>' +
               '<p><strong>Description</strong>: Whether the element is accessible or not; when FALSE, the element is not rendered and the user submitted value is not taken into consideration.</p>' +
-              '<p><strong>Values</strong>: TRUE or FALSE.</p>'
+              '<p><strong>Values</strong>: TRUE or FALSE.</p>')
               });
             }
           }
@@ -507,15 +507,15 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textfield',
           id: 'autocomplete_path',
           name: 'autocomplete_path',
-          fieldLabel: 'Autocomplete Path',
+          fieldLabel: Drupal.t('Autocomplete Path'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'autocomplete_path',
                 anchor: 'left',
-                html: '<h3><a name="autocomplete_path" id="autocomplete_path"></a>#autocomplete_path</h3>' +
+                html: Drupal.t('<h3><a name="autocomplete_path" id="autocomplete_path"></a>#autocomplete_path</h3>' +
               '<p><strong>Used by</strong>: <a href="#textfield">textfield</a></p>' +
-              '<p><strong>Description</strong>: The path the AJAX autocomplete script uses as the source for autocompletion.</p>'
+              '<p><strong>Description</strong>: The path the AJAX autocomplete script uses as the source for autocompletion.</p>')
               });
             }
           }
@@ -523,16 +523,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textfield',
           id: 'button_type',
           name: 'button_type',
-          fieldLabel: 'Button Type',
+          fieldLabel: Drupal.t('Button Type'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'button_type',
                 anchor: 'left',
-                html: '<h3><a name="button_type" id="button_type"></a>#button_type</h3>' +
+                html: Drupal.t('<h3><a name="button_type" id="button_type"></a>#button_type</h3>' +
               '<p><strong>Used by</strong>: <a href="#button">button</a>, <a href="#image_button">image_button</a>, <a href="#submit">submit</a></p>' +
               '<p><strong>Description</strong>: Adds a CSS class to the button, in the form <em>form-[button_type_value]</em>. Note that this does NOT set the HTML attribute <em>type</em> of the button.</p>' +
-              '<p class="help"><strong>Values</strong>: String </p>'
+              '<p class="help"><strong>Values</strong>: String </p>')
               });
             }
           }
@@ -540,16 +540,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'numberfield',
           id: 'cols',
           name: 'cols',
-          fieldLabel: 'Cols',
+          fieldLabel: Drupal.t('Cols'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'cols',
                 anchor: 'left',
-                html: '<h3><a name="cols" id="cols"></a>#cols</h3>' +
+                html: Drupal.t('<h3><a name="cols" id="cols"></a>#cols</h3>' +
               '<p><strong>Used by</strong>: <a href="#textarea">textarea</a></p>' +
               '<p><strong>Description</strong>: How many columns wide the textarea should be (see also <a href="#rows">#rows</a>)</p>' +
-              '<p><strong>Values</strong>: A positive number</p>'
+              '<p><strong>Values</strong>: A positive number</p>')
               });
             }
           }
@@ -557,17 +557,17 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'checkbox',
           id: 'disabled',
           name: 'disabled',
-          fieldLabel: 'Disabled',
+          fieldLabel: Drupal.t('Disabled'),
           inputValue: true,
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'disabled',
                 anchor: 'left',
-                html: '<h3><a name="disabled" id="disabled"></a>#disabled</h3>' +
+                html: Drupal.t('<h3><a name="disabled" id="disabled"></a>#disabled</h3>' +
               '<p><strong>Used by</strong>: <a href="#button">button</a>, <a href="#checkbox">checkbox</a>, <a href="#checkboxes">checkboxes</a>, <a href="#date">date</a>, <a href="#file">file</a>, <a href="#image_button">image_button</a>, <a href="#password">password</a>, <a href="#password_confirm">password_confirm</a>, <a href="#radio">radio</a>, <a href="#radios">radios</a>, <a href="#select">select</a>, <a href="#submit">submit</a>, <a href="#textarea">textarea</a>, <a href="#textfield">textfield</a>, <a href="#weight">weight</a></p>' +
               '<p><strong>Description</strong>: Disables (greys out) a form input element. Note that disabling a form field doesn\'t necessarily prevent someone from submitting a value through DOM manipulation. It just tells the browser not to accept input.</p>' +
-              '<p><strong>Values</strong>: TRUE or FALSE</p>'
+              '<p><strong>Values</strong>: TRUE or FALSE</p>')
               });
             }
           }
@@ -575,16 +575,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'numberfield',
           id: 'delta',
           name: 'delta',
-          fieldLabel: 'Delta',
+          fieldLabel: Drupal.t('Delta'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'delta',
                 anchor: 'left',
-                html: '<h3><a name="delta" id="delta"></a>#delta</h3>' +
+                html: Drupal.t('<h3><a name="delta" id="delta"></a>#delta</h3>' +
               '<p><strong>Used by</strong>: <a href="#weight">weight</a></p>' +
               '<p><strong>Description</strong>: Number of weights to have selectable. For example, with $delta =&gt; 10, the weight selection box would display numbers from -10 to 10.</p>' +
-              '<p><strong>Values</strong>: A positive number</p>'
+              '<p><strong>Values</strong>: A positive number</p>')
               });
             }
           }
@@ -592,16 +592,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textfield',
           id: 'prefix',
           name: 'prefix',
-          fieldLabel: 'Prefix',
+          fieldLabel: Drupal.t('Prefix'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'prefix',
                 anchor: 'left',
-                html: '<h3><a name="prefix" id="prefix"></a>#prefix</h3>' +
+                html: Drupal.t('<h3><a name="prefix" id="prefix"></a>#prefix</h3>' +
               '<p><strong>Used by</strong>: All elements and forms.</p>' +
               '<p><strong>Description</strong>: Text or markup to include before the form element. Also see <a href="#suffix">#suffix</a>.</p>' +
-              '<p><strong>Values</strong>: Mixed</p>'
+              '<p><strong>Values</strong>: Mixed</p>')
               });
             }
           }
@@ -609,16 +609,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textfield',
           id: 'suffix',
           name: 'suffix',
-          fieldLabel: 'Suffix',
+          fieldLabel: Drupal.t('Suffix'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'suffix',
                 anchor: 'left',
-                html: '<h3><a name="suffix" id="suffix"></a>#suffix</h3>' +
+                html: Drupal.t('<h3><a name="suffix" id="suffix"></a>#suffix</h3>' +
               '<p><strong>Used by</strong>: All elements and forms</p>' +
               '<p><strong>Description</strong>: Text or markup to include after the form element. Also see <a href="#prefix">#prefix</a>.</p>' +
-              '<p><strong>Values</strong>: Mixed</p>'
+              '<p><strong>Values</strong>: Mixed</p>')
               });
             }
           }
@@ -626,16 +626,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textfield',
           id: 'theme',
           name: 'theme',
-          fieldLabel: 'Theme',
+          fieldLabel: Drupal.t('Theme'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'theme',
                 anchor: 'left',
-                html: '<h3><a name="theme" id="theme"></a>#theme</h3>' +
+                html: Drupal.t('<h3><a name="theme" id="theme"></a>#theme</h3>' +
               '<p><strong>Used by</strong>: All elements and forms.</p>' +
               '<p><strong>Description</strong>: Theme function to call for element.</p>' +
-              '<p><strong>Values</strong>: The name of a theme function, without the initial theme_.</p>'
+              '<p><strong>Values</strong>: The name of a theme function, without the initial theme_.</p>')
               });
             }
           }
@@ -643,16 +643,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'numberfield',
           id: 'weight',
           name: 'weight',
-          fieldLabel: 'Weight',
+          fieldLabel: Drupal.t('Weight'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'weight',
                 anchor: 'left',
-                html: '<h3><a name="weightval" id="weightval"></a>#weight</h3>' +
+                html: Drupal.t('<h3><a name="weightval" id="weightval"></a>#weight</h3>' +
               '<p><strong>Used by</strong>: All elements</p>' +
               '<p><strong>Description</strong>: Used to sort the list of form elements before being output; lower numbers appear before higher numbers.</p>' +
-              '<p><strong>Values</strong>: A positive or negative number (integer or decimal)</p>'
+              '<p><strong>Values</strong>: A positive or negative number (integer or decimal)</p>')
               });
             }
           }
@@ -660,7 +660,7 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'checkbox',
           id: 'tree',
           name: 'tree',
-          fieldLabel: 'Tree',
+          fieldLabel: Drupal.t('Tree'),
           checked: true,
           inputValue: true,
           listeners: {
@@ -668,10 +668,10 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'tree',
                 anchor: 'left',
-                html: '<h3><a name="tree" id="tree"></a>#tree</h3>' +
+                html: Drupal.t('<h3><a name="tree" id="tree"></a>#tree</h3>' +
               '<p><strong>Used by</strong>: All</p>' +
               '<p><strong>Description</strong>: Used to allow collections of form elements. Normally applied to the "parent" element, as the #tree property cascades to sub-elements. Use where you previously used ][ in form_ calls. For more information, see <a href="http://drupal.org/node/48643">#tree and #parents</a> in the handbook.</p>' +
-              '<p><strong>Values</strong>: TRUE or FALSE</p>'
+              '<p><strong>Values</strong>: TRUE or FALSE</p>')
               });
             }
           }
@@ -679,16 +679,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textfield',
           id: 'field_prefix',
           name: 'field_prefix',
-          fieldLabel: 'Field Prefix',
+          fieldLabel: Drupal.t('Field Prefix'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'field_prefix',
                 anchor: 'left',
-                html: '<h3><a name="field_prefix" id="field_prefix"></a>#field_prefix</h3>' +
+                html: Drupal.t('<h3><a name="field_prefix" id="field_prefix"></a>#field_prefix</h3>' +
               '<p><strong>Used by</strong>: <a href="#textfield">textfield</a></p>' +
               '<p><strong>Description</strong>: Text or code that is placed directly in front of the textfield. This can be used to prefix a textfield with a constant string.</p>' +
-              '<p><strong>Values</strong>: Mixed</p>'
+              '<p><strong>Values</strong>: Mixed</p>')
               });
             }
           }
@@ -696,16 +696,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textfield',
           id: 'field_suffix',
           name: 'field_suffix',
-          fieldLabel: 'Field Suffix',
+          fieldLabel: Drupal.t('Field Suffix'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'field_suffix',
                 anchor: 'left',
-                html: '<h3><a name="field_suffix" id="field_suffix"></a>#field_suffix</h3>' +
+                html: Drupal.t('<h3><a name="field_suffix" id="field_suffix"></a>#field_suffix</h3>' +
               '<p><strong>Used by</strong>: <a href="#textfield">textfield</a></p>' +
               '<p><strong>Description</strong>: Text or code that is placed directly after a textfield. This can be used to add a unit to a textfield.</p>' +
-              '<p><strong>Values</strong>: Mixed</p>'
+              '<p><strong>Values</strong>: Mixed</p>')
               });
             }
           }
@@ -713,16 +713,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'numberfield',
           id: 'maxlength',
           name: 'maxlength',
-          fieldLabel: 'Max Length',
+          fieldLabel: Drupal.t('Max Length'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'maxlength',
                 anchor: 'left',
-                html: '<h3><a name="maxlength" id="maxlength"></a>#maxlength</h3>' +
+                html: Drupal.t('<h3><a name="maxlength" id="maxlength"></a>#maxlength</h3>' +
               '<p><strong>Used by</strong>: <a href="#password">password</a>, <a href="#textfield">textfield</a></p>' +
               '<p><strong>Description</strong>: The maximum amount of characters to accept as input.</p>' +
-              '<p><strong>Values</strong>: A positive number.</p>'
+              '<p><strong>Values</strong>: A positive number.</p>')
               });
             }
           }
@@ -730,7 +730,7 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'combobox',
           id: 'method',
           name: 'method',
-          fieldLabel: 'Method',
+          fieldLabel: Drupal.t('Method'),
           displayField: 'display',
           valueField: 'value',
           editable: false,
@@ -738,10 +738,10 @@ Ext.formbuilder.createElementForm = function () {
           store: new Ext.data.Store({
             fields: ['display', 'value'],
             data: [{
-              display: 'Post',
+              display: Drupal.t('Post'),
               value: 'post'
             },{
-              display: 'Get',
+              display: Drupal.t('Get'),
               value: 'get'
             }]
           }),
@@ -750,10 +750,10 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'method',
                 anchor: 'left',
-                html: '<h3><a name="method" id="method"></a>#method</h3>' +
+                html: Drupal.t('<h3><a name="method" id="method"></a>#method</h3>' +
               '<p><strong>Used by</strong>: <a href="#form">form</a></p>' +
               '<p><strong>Description</strong>: The HTTP method with which the form will be submitted.</p>' +
-              '<p><strong>Values</strong>: GET or POST. Default is POST.</p>'
+              '<p><strong>Values</strong>: GET or POST. Default is POST.</p>')
               });
             }
           }
@@ -761,16 +761,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textfield',
           id: 'name',
           name: 'name',
-          fieldLabel: 'Name',
+          fieldLabel: Drupal.t('Name'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'name',
                 anchor: 'left',
-                html: '<h3 class="help"><a name="name" id="name"></a>#name</h3>' +
+                html: Drupal.t('<h3 class="help"><a name="name" id="name"></a>#name</h3>' +
               '<p><strong>Used by</strong>: <a href="#button">button</a>, <a href="#submit">submit</a></p>' +
               '<p><strong>Description</strong>: INTERNAL, except for buttons. All button and submit elements on a form should have the same name, which is set to \'op\' by default in Drupal. This does not apply to image buttons. For non-button elements, Drupal sets the name by using \'foo\' in $form[\'foo\'] as well as any parents of the element.</p>' +
-              '<p><strong>Values</strong>: String.</p>'
+              '<p><strong>Values</strong>: String.</p>')
               });
             }
           }
@@ -778,16 +778,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textfield',
           id: 'value',
           name: 'value',
-          fieldLabel: 'Value',
+          fieldLabel: Drupal.t('Value'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'value',
                 anchor: 'left',
-                html: '<h3><a name="value" id="value"></a>#value</h3>' +
+                html: Drupal.t('<h3><a name="value" id="value"></a>#value</h3>' +
               '<p><strong>Used by</strong>: <a href="#button">button</a>, <a href="#hidden">hidden</a>, <a href="#image_button">image_button</a>, <a href="#item">item</a>, <a href="#markup">markup</a>, <a href="#submit">submit</a>, <a href="#token">token</a>, <a href="#val">value</a></p>' +
               '<p><strong>Description</strong>: Used to set values that cannot be edited by the user. <strong>Should NOT be confused with <a href="#default_value">#default_value</a></strong>, which is for form inputs where users can override the default value.</p>' +
-              '<p><strong>Values</strong>: Mixed (text or numbers)</p>'
+              '<p><strong>Values</strong>: Mixed (text or numbers)</p>')
               });
             }
           }
@@ -795,16 +795,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textfield',
           id: 'return_value',
           name: 'return_value',
-          fieldLabel: 'Return Value',
+          fieldLabel: Drupal.t('Return Value'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'return_value',
                 anchor: 'left',
-                html: '<h3><a name="return_value" id="return_value"></a>#return_value</h3>' +
+                html: Drupal.t('<h3><a name="return_value" id="return_value"></a>#return_value</h3>' +
               '<p><strong>Used by</strong>: <a href="#checkbox">checkbox</a>, <a href="#image_button">image_button</a>, <a href="#radio">radio</a></p>' +
               '<p><strong>Description</strong>: Value element should return when selected</p>' +
-              '<p><strong>Values</strong>: Mixed</p>'
+              '<p><strong>Values</strong>: Mixed</p>')
               });
             }
           }
@@ -812,16 +812,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'numberfield',
           id: 'rows',
           name: 'rows',
-          fieldLabel: 'Rows',
+          fieldLabel: Drupal.t('Rows'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'rows',
                 anchor: 'left',
-                html: '<h3><a name="rows" id="rows"></a>#rows</h3>' +
+                html: Drupal.t('<h3><a name="rows" id="rows"></a>#rows</h3>' +
               '<p><strong>Used by</strong>: <a href="#textarea">textarea</a></p>' +
               '<p><strong>Description</strong>: How many rows high the textarea should be (see also <a href="#cols">#cols</a>)</p>' +
-              '<p><strong>Values</strong>: A positive number</p>'
+              '<p><strong>Values</strong>: A positive number</p>')
               });
             }
           }
@@ -829,16 +829,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'numberfield',
           id: 'size',
           name: 'size',
-          fieldLabel: 'Size',
+          fieldLabel: Drupal.t('Size'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'size',
                 anchor: 'left',
-                html: '<h3><a name="size" id="size"></a>#size</h3>' +
+                html: Drupal.t('<h3><a name="size" id="size"></a>#size</h3>' +
               '<p><strong>Used by</strong>:  <a href="#password">password</a>, <a href="#password_confirm">password_confirm</a>, <a href="#select">select</a>, <a href="#textfield">textfield</a></p>' +
               '<p><strong>Description</strong>: Width of the textfield (in characters) or size of multiselect box (in lines).</p>' +
-              '<p><strong>Values</strong>: A positive number.</p>'
+              '<p><strong>Values</strong>: A positive number.</p>')
               });
             }
           }
@@ -846,16 +846,16 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'textfield',
           id: 'src',
           name: 'src',
-          fieldLabel: 'Src',
+          fieldLabel: Drupal.t('Src'),
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'src',
                 anchor: 'left',
-                html: '<h3><a name="src" id="src"></a>#src</h3>' +
+                html: Drupal.t('<h3><a name="src" id="src"></a>#src</h3>' +
               '<p><strong>Used by</strong>: <a href="#image_button">image_button</a></p>' +
               '<p><strong>Description</strong>: The URL of the image of the button.</p>' +
-              '<p><strong>Values</strong>: An URL.</p>'
+              '<p><strong>Values</strong>: An URL.</p>')
               });
             }
           }
@@ -863,17 +863,17 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'checkbox',
           id: 'collapsed',
           name: 'collapsed',
-          fieldLabel: 'Collapsed',
+          fieldLabel: Drupal.t('Collapsed'),
           inputValue: true,
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'collapsed',
                 anchor: 'left',
-                html: '<h3><a name="collapsed" id="collapsed"></a>#collapsed</h3>' +
+                html: Drupal.t('<h3><a name="collapsed" id="collapsed"></a>#collapsed</h3>' +
               '<p><strong>Used by</strong>: <a href="#fieldset">fieldset</a></p>' +
               '<p><strong>Description</strong>: Indicates whether or not the fieldset is collapsed by default. See <a href="#collapsible">#collapsible</a> property.</p>' +
-              '<p><strong>Values</strong>: TRUE or FALSE</p>'
+              '<p><strong>Values</strong>: TRUE or FALSE</p>')
               });
             }
           }
@@ -881,17 +881,17 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'checkbox',
           id: 'collapsible',
           name: 'collapsible',
-          fieldLabel: 'Collapsible',
+          fieldLabel: Drupal.t('Collapsible'),
           inputValue: true,
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'collapsible',
                 anchor: 'left',
-                html: '<h3><a name="collapsible" id="collapsible"></a>#collapsible</h3>' +
+                html: Drupal.t('<h3><a name="collapsible" id="collapsible"></a>#collapsible</h3>' +
               '<p><strong>Used by</strong>: <a href="#fieldset">fieldset</a></p>' +
               '<p><strong>Description</strong>: Indicates whether or not the fieldset can be collapsed with JavaScript. See <a href="#collapsed">#collapsed</a> property.</p>' +
-              '<p><strong>Values</strong>: TRUE or FALSE</p>'
+              '<p><strong>Values</strong>: TRUE or FALSE</p>')
               });
             }
           }
@@ -906,10 +906,10 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'executes_submit_callback',
                 anchor: 'left',
-                html: '<h3><a name="executes_submit_callback" id="executes_submit_callback"></a>#executes_submit_callback</h3>' +
+                html: Drupal.t('<h3><a name="executes_submit_callback" id="executes_submit_callback"></a>#executes_submit_callback</h3>' +
               '<p><strong>Used by</strong>: <a href="#button">button</a>, <a href="#image_button">image_button</a>, <a href="#submit">submit</a></p>' +
               '<p><strong>Description</strong>: Indicates whether or not button should submit the form.</p>' +
-              '<p><strong>Values</strong>: TRUE or FALSE</p>'
+              '<p><strong>Values</strong>: TRUE or FALSE</p>')
               });
             }
           }
@@ -917,17 +917,17 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'checkbox',
           id: 'multiple',
           name: 'multiple',
-          fieldLabel: 'Multiple',
+          fieldLabel: Drupal.t('Multiple'),
           inputValue: true,
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'multiple',
                 anchor: 'left',
-                html: '<h3><a name="multiple" id="multiple"></a>#multiple</h3>' +
+                html: Drupal.t('<h3><a name="multiple" id="multiple"></a>#multiple</h3>' +
               '<p><strong>Used by</strong>: <a href="#select">select</a></p>' +
               '<p><strong>Description</strong>: Indicates whether the user may select more than one item.</p>' +
-              '<p><strong>Values</strong>: TRUE or FALSE</p>'
+              '<p><strong>Values</strong>: TRUE or FALSE</p>')
               });
             }
           }
@@ -935,17 +935,17 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'checkbox',
           id: 'resizable',
           name: 'resizable',
-          fieldLabel: 'Resizable',
+          fieldLabel: Drupal.t('Resizable'),
           inputValue: true,
           listeners: {
             render: function() {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'resizable',
                 anchor: 'left',
-                html: '<h3><a name="resizable" id="resizable"></a>#resizable</h3>' +
+                html: Drupal.t('<h3><a name="resizable" id="resizable"></a>#resizable</h3>' +
               '<p><strong>Used by</strong>: <a href="#textarea">textarea</a></p>' +
               '<p><strong>Description</strong>: Whether users should be allowed to resize the text area</p>' +
-              '<p><strong>Values</strong>: TRUE or FALSE</p>'
+              '<p><strong>Values</strong>: TRUE or FALSE</p>')
               });
             }
           }
@@ -954,7 +954,7 @@ Ext.formbuilder.createElementForm = function () {
           checkboxToggle: true,
           checkboxName: 'ajax',
           collapsed: true,
-          title: 'AJAX',
+          title: Drupal.t('AJAX'),
           id: 'ajax',
           layout: 'anchor',
           defaults: {
@@ -970,9 +970,9 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'ahah-effect',
                   anchor: 'left',
-                  html:  '<h3><a name="ahah_effect" id="ahah_effect"></a>#ajax[\'effect\']</h3>' +
+                  html:  Drupal.t('<h3><a name="ahah_effect" id="ahah_effect"></a>#ajax[\'effect\']</h3>' +
                 '<p><strong>Description</strong>: Specifies the effect used when adding the content from an AHAH request. </p>' +
-                '<p><strong>Values</strong>: String. Possible values: \'none\' (default), \'fade\', \'slide\'. If the <a href="http://interface.eyecon.ro/">interface elements library</a> is installed, any effect with the name <em>effect</em>Toggle may also be used. </p>'
+                '<p><strong>Values</strong>: String. Possible values: \'none\' (default), \'fade\', \'slide\'. If the <a href="http://interface.eyecon.ro/">interface elements library</a> is installed, any effect with the name <em>effect</em>Toggle may also be used. </p>')
                 });
               }
             }
@@ -980,16 +980,16 @@ Ext.formbuilder.createElementForm = function () {
             xtype: 'textfield',
             id: 'ahah-event',
             name: 'ahah_event',
-            fieldLabel: 'Event',
+            fieldLabel: Drupal.t('Event'),
             listeners: {
               render: function() {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'ahah-event',
                   anchor: 'left',
-                  html: '<h3><a name="ahah_event" id="ahah_event"></a>#ajax[\'event\']</h3>' +
+                  html: Drupal.t('<h3><a name="ahah_event" id="ahah_event"></a>#ajax[\'event\']</h3>' +
                 '<p><strong>Description</strong>: When this event occurs to this element, Drupal will perform an HTTP request in the background via Javascript.</p>' +
                 '<p><strong>Values</strong>: String. Possible values: Any valid <a href="http://docs.jquery.com/Events">jQuery event</a>, including \'mousedown\', \'blur\', and \'change\'.'+
-                'Note that #ajax[\'event\'] does not need to be explicitly specified. Although it can be manually set, usually the <a href="#element_default_values">default value </a> will be sufficient.</p>'
+                'Note that #ajax[\'event\'] does not need to be explicitly specified. Although it can be manually set, usually the <a href="#element_default_values">default value </a> will be sufficient.</p>')
                 });
               }
             }
@@ -997,15 +997,15 @@ Ext.formbuilder.createElementForm = function () {
             xtype: 'textfield',
             id: 'ahah-method',
             name: 'ahah_method',
-            fieldLabel: 'Method',
+            fieldLabel: Drupal.t('Method'),
             listeners: {
               render: function() {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'ahah-method',
                   anchor: 'left',
-                  html: '<h3><a name="ahah_method" id="ahah_method"></a>#ajax[\'method\']</h3>' +
+                  html: Drupal.t('<h3><a name="ahah_method" id="ahah_method"></a>#ajax[\'method\']</h3>' +
                 '<p><strong>Description</strong>: Modify the behavior of the returned HTML from an AHAH request when inserting into the <a href="#ajax_wrapper">#ajax_wrapper</a>. If not set, the returned HTML will replace the contents of the wrapper element, but it\'s also possible to use any of the available <a href="http://docs.jquery.com/DOM/Manipulation">jQuery operations for DOM manipulation</a>. </p>' +
-                '<p><strong>Values</strong>: String. Possible values: \'replace\' (default), \'after\', \'append\', \'before\', \'prepend\'.</p>'
+                '<p><strong>Values</strong>: String. Possible values: \'replace\' (default), \'after\', \'append\', \'before\', \'prepend\'.</p>')
                 });
               }
             }
@@ -1013,15 +1013,15 @@ Ext.formbuilder.createElementForm = function () {
             xtype: 'textfield',
             id: 'ahah-path',
             name: 'ahah_path',
-            fieldLabel: 'Path',
+            fieldLabel: Drupal.t('Path'),
             listeners: {
               render: function() {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'ahah-path',
                   anchor: 'left',
-                  html: '<h3><a name="ahah_path" id="ahah_path"></a>#ajax[\'path\']</h3>' +
+                  html: Drupal.t('<h3><a name="ahah_path" id="ahah_path"></a>#ajax[\'path\']</h3>' +
                 '<p><strong>Description</strong>: If set, this property triggers AHAH behaviors on a form element. This is the Drupal menu path to a callback function which will generate HTML and return the string of HTML to Drupal. The result will be placed in the div specified in <a href="#ajax_wrapper">#ajax[\'wrapper\']</a>. </p>' +
-                '<p><strong>Values</strong>: String containing a Drupal menu path.</p>'
+                '<p><strong>Values</strong>: String containing a Drupal menu path.</p>')
                 });
               }
             }
@@ -1029,15 +1029,15 @@ Ext.formbuilder.createElementForm = function () {
             xtype: 'textfield',
             id: 'ahah-wrapper',
             name: 'ahah_wrapper',
-            fieldLabel: 'Wrapper',
+	fieldLabel: Drupal.t('Wrapper'),
             listeners: {
               render: function() {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'ahah-wrapper',
                   anchor: 'left',
-                  html: '<h3><a name="ahah_wrapper" id="ahah_wrapper"></a>#ajax[\'wrapper\']</h3>' +
+                  html: Drupal.t('<h3><a name="ahah_wrapper" id="ahah_wrapper"></a>#ajax[\'wrapper\']</h3>' +
                 '<p><strong>Description</strong>: This property defines the HTML id attribute of an element on the page will server as the destination for HTML returned by an AHAH request. Usually, a div element is used as the wrapper, as it provides the most flexibility for placement of elements before, after, or inside of it\'s HTML tags. This property  is required for using AHAH requests in on a form element.</p>' +
-                '<p><strong>Values</strong>: String containg a valid id attribute of an HTML element on the same page.</p>'
+                '<p><strong>Values</strong>: String containg a valid id attribute of an HTML element on the same page.</p>')
                 });
               }
             }
@@ -1045,15 +1045,15 @@ Ext.formbuilder.createElementForm = function () {
             xtype: 'checkbox',
             id: 'ahah-keypress',
             name: 'ahah_keypress',
-            fieldLabel: 'Keypress',
+            fieldLabel: Drupal.t('Keypress'),
             inputValue: true,
             listeners: {
               render: function() {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'ahah-keypress',
                   anchor: 'left',
-                  html: '<h3><a name="ahah_keypress" id="ahah_keypress"></a>#ajax[\'keypress\']</h3>' +
-                '<p><strong>Description</strong>: If set to TRUE, then the element\'s #ajax[\'event\'] will be triggered if the ENTER key is pressed while the element has focus.</p>'
+                  html: Drupal.t('<h3><a name="ahah_keypress" id="ahah_keypress"></a>#ajax[\'keypress\']</h3>' +
+                '<p><strong>Description</strong>: If set to TRUE, then the element\'s #ajax[\'event\'] will be triggered if the ENTER key is pressed while the element has focus.</p>')
                 });
               }
             }
@@ -1063,19 +1063,19 @@ Ext.formbuilder.createElementForm = function () {
             collapsed: true,
             checkboxName: 'ahah_progress',
             id: 'ahah_progress',
-            title: 'Progress',
+            title: Drupal.t('Progress'),
             items: [{
               xtype: 'textfield',
               id: 'ahah-progress-type',
               name: 'ahah_progress_type',
-              fieldLabel: 'Type',
+              fieldLabel: Drupal.t('Type'),
               listeners: {
                 render: function() {
                   Ext.create('Ext.tip.ToolTip', {
                     target: 'ahah-progress-type',
                     anchor: 'top',
-                    html: '<p>Possible values:</p>' +
-                  '<ul><li><strong>#ajax[\'progress\'][\'type\']</strong> String. Possible values: \'throbber\' (default), \'bar\'.</li></ul>'
+                    html: Drupal.t('<p>Possible values:</p>' +
+                  '<ul><li><strong>#ajax[\'progress\'][\'type\']</strong> String. Possible values: \'throbber\' (default), \'bar\'.</li></ul>')
                   });
                 }
               }
@@ -1083,14 +1083,14 @@ Ext.formbuilder.createElementForm = function () {
               xtype: 'textfield',
               id: 'ahah-progress-message',
               name: 'ahah_progress_message',
-              fieldLabel: 'Message',
+              fieldLabel: Drupal.t('Message'),
               listeners: {
                 render: function() {
                   Ext.create('Ext.tip.ToolTip', {
                     target: 'ahah-progress-message',
                     anchor: 'top',
-                    html: '<p>Possible values:</p>' +
-                  '<ul><li><strong>#ajax[\'progress\'][\'message\']</strong> String.  An optional message to the user; should be wrapped with <a href="/api/drupal/includes--common.inc/function/t/6" title="Translate strings to the page language or a given language." class="local">t</a>().</li></ul>'
+                    html: Drupal.t('<p>Possible values:</p>' +
+                  '<ul><li><strong>#ajax[\'progress\'][\'message\']</strong> String.  An optional message to the user; should be wrapped with <a href="/api/drupal/includes--common.inc/function/t/6" title="Translate strings to the page language or a given language." class="local">t</a>().</li></ul>')
                   });
                 }
               }
@@ -1098,14 +1098,14 @@ Ext.formbuilder.createElementForm = function () {
               xtype: 'textfield',
               id: 'ahah-progress-url',
               name: 'ahah_progress_url',
-              fieldLabel: 'Url',
+              fieldLabel: Drupal.t('Url'),
               listeners: {
                 render: function() {
                   Ext.create('Ext.tip.ToolTip', {
                     target: 'ahah-progress-url',
                     anchor: 'top',
-                    html: '<p>Possible values:</p>' +
-                  '<ul><li><strong>#ajax[\'progress\'][\'url\']</strong> String. The optional callback path to use to determine how full the progress bar is (as defined in progress.js). Only useable when \'type\' is \'bar\'.</li></ul>'
+                    html: Drupal.t('<p>Possible values:</p>' +
+                  '<ul><li><strong>#ajax[\'progress\'][\'url\']</strong> String. The optional callback path to use to determine how full the progress bar is (as defined in progress.js). Only useable when \'type\' is \'bar\'.</li></ul>')
                   });
                 }
               }
@@ -1113,14 +1113,14 @@ Ext.formbuilder.createElementForm = function () {
               xtype: 'textfield',
               id: 'ahah-progress-interval',
               name: 'ahah_progress_interval',
-              fieldLabel: 'Interval',
+              fieldLabel: Drupal.t('Interval'),
               listeners: {
                 render: function() {
                   Ext.create('Ext.tip.ToolTip', {
                     target: 'ahah-progress-interval',
                     anchor: 'top',
-                    html: '<p>Possible values:</p>' +
-                  '<li><strong>#ajax[\'progress\'][\'interval\']</strong> String. The interval to be used in updating the progress bar (as defined in progress.js).  Ony used if \'url\' is defined and \'type\' is \'bar\'.</li>'
+                    html: Drupal.t('<p>Possible values:</p>' +
+                  '<li><strong>#ajax[\'progress\'][\'interval\']</strong> String. The interval to be used in updating the progress bar (as defined in progress.js).  Ony used if \'url\' is defined and \'type\' is \'bar\'.</li>')
                   });
                 }
               }
@@ -1130,10 +1130,10 @@ Ext.formbuilder.createElementForm = function () {
                 Ext.create('Ext.tip.ToolTip', {
                   target: 'ahah-progress',
                   anchor: 'bottom',
-                  html: '<h3><a name="ahah_progress" id="ahah_progress"></a>#ajax[\'progress\']</h3>' +
+                  html: Drupal.t('<h3><a name="ahah_progress" id="ahah_progress"></a>#ajax[\'progress\']</h3>' +
                 '<p><strong>Description</strong>: Choose either a throbber or progress bar that is displayed while awaiting a response from the callback, and add an optional message.</p>' +
                 '<p><strong>Values</strong>: Array.</p>' +
-                '<p>Possible keys: \'type\', \'message\', \'url\', \'interval\'</p>'
+                '<p>Possible keys: \'type\', \'message\', \'url\', \'interval\'</p>')
                 });
               }
             }
@@ -1143,7 +1143,7 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'ahah',
                 anchor: 'left',
-                html: '<h3><a name="ajax" id="ajax"></a>#ajax</h3>' +
+                html: Drupal.t('<h3><a name="ajax" id="ajax"></a>#ajax</h3>' +
               '<p><strong>Used by</strong>:' +
               '<a href="#button">button</a>,' +
               '<a href="#checkbox">checkbox</a>,' +
@@ -1156,19 +1156,19 @@ Ext.formbuilder.createElementForm = function () {
               '<a href="#textarea">textarea</a>,' +
               '<a href="#textfield">textfield</a>' +
               '</p>' +
-              '<p>An array of elements whose values control the behavior of the element with respect to the Drupal AHAH javascript methods.</p>'
+              '<p>An array of elements whose values control the behavior of the element with respect to the Drupal AHAH javascript methods.</p>')
               });
             }
           }
         }]
       }, {
-        title: 'More Advanced Controls',
+        title: Drupal.t('More Advanced Controls'),
         autoScroll: true,
         items: [{
           xtype: 'formgrid',
           id: 'attributes',
           name: 'attributes',
-          title: 'Attributes',
+          title: Drupal.t('Attributes'),
           store: Ext.create('Ext.data.Store', {
             fields:['key', 'value'],
             proxy: {
@@ -1185,7 +1185,7 @@ Ext.formbuilder.createElementForm = function () {
           columns: [{
             xtype: 'gridcolumn',
             dataIndex: 'key',
-            header: 'Key',
+            header: Drupal.t('Key'),
             sortable: true,
             width: 200,
             field: {
@@ -1194,7 +1194,7 @@ Ext.formbuilder.createElementForm = function () {
           },{
             xtype: 'gridcolumn',
             dataIndex: 'value',
-            header: 'Value',
+            header: Drupal.t('Value'),
             sortable: true,
             flex: 1,
             field: {
@@ -1206,10 +1206,10 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'attributes',
                 anchor: 'left',
-                html: '<h3><a name="attributes" id="attributes"></a>#attributes</h3>' +
+                html: Drupal.t('<h3><a name="attributes" id="attributes"></a>#attributes</h3>' +
               '<p><strong>Used by</strong>: <a href="#button">button</a>, <a href="#checkbox">checkbox</a>, <a href="#checkboxes">checkboxes</a>, <a href="#date">date</a>, <a href="#fieldset">fieldset</a>, <a href="#file">file</a>, <a href="#form">form</a>, <a href="#image_button">image_button</a>, <a href="#password">password</a>, <a href="#radio">radio</a>, <a href="#radios">radios</a>, <a href="#select">select</a>, <a href="#submit">submit</a>, <a href="#textarea">textarea</a>, <a href="#textfield">textfield</a>, <a href="#weight">weight</a></p>' +
               '<p><strong>Description</strong>: Additional HTML attributes, such as \'class\' can be set using this mechanism.</p>' +
-              '<p><strong>Values</strong>: Any HTML attribute not covered by other properties, e.g. <strong>class</strong> (for control types), <strong>enctype</strong> (for forms).</p>'
+              '<p><strong>Values</strong>: Any HTML attribute not covered by other properties, e.g. <strong>class</strong> (for control types), <strong>enctype</strong> (for forms).</p>')
               });
             }
           }
@@ -1217,7 +1217,7 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'formgrid',
           id: 'element_validate',
           name: 'element_validate',
-          title: 'Element Validate',
+          title: Drupal.t('Element Validate'),
           store: Ext.create('Ext.data.Store', {
             fields:['value'],
             proxy: {
@@ -1245,16 +1245,16 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'element_validate',
                 anchor: 'left',
-                html: '<h3><a name="element_validate" id="element_validate"></a>#element_validate</h3>' +
+                html: Drupal.t('<h3><a name="element_validate" id="element_validate"></a>#element_validate</h3>' +
               '<p class="help"><strong>Used by</strong>: any element</p>' +
               '<p><strong>Description</strong>: A list of custom validation functions that need to be passed. The functions must use <a href="/api/drupal/includes--form.inc/function/form_error/6" title="Flag an element as having an error." class="local">form_error</a>() or <a href="/api/drupal/includes--form.inc/function/form_set_error/6" title="File an error against a form element." class="local">form_set_error</a>() to set an error if the validation fails.</p>' +
-              '<p><strong>Values</strong>: an array of function names to be called to validate this element (and/or its children).</p>'
+              '<p><strong>Values</strong>: an array of function names to be called to validate this element (and/or its children).</p>')
               });
             }
           }
         },  {
           xtype: 'formgrid',
-          title: 'Process',
+          title: Drupal.t('Process'),
           id: 'process',
           name: 'process',
           store: Ext.create('Ext.data.Store', {
@@ -1272,7 +1272,7 @@ Ext.formbuilder.createElementForm = function () {
           columns: [{
             xtype: 'gridcolumn',
             dataIndex: 'value',
-            header: 'Functions',
+            header: Drupal.t('Functions'),
             sortable: true,
             flex: 1,
             field: {
@@ -1284,15 +1284,15 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'process',
                 anchor: 'left',
-                html: '<h3><a name="process"></a>#process</h3>' +
+                html: Drupal.t('<h3><a name="process"></a>#process</h3>' +
               '<p><strong>Description</strong>: An array of functions that are called when an element is processed. Using this callback, modules can "register" further actions. For example the "radios" form type is expanded to multiple radio buttons using a processing function.</p>' +
-              '<p><strong>Values</strong>: Array of function names (strings)</p>'
+              '<p><strong>Values</strong>: Array of function names (strings)</p>')
               });
             }
           }
         }, {
           xtype: 'formgrid',
-          title: 'Pre Render',
+          title: Drupal.t('Pre Render'),
           id: 'pre_render',
           name: 'pre_render',
           store: Ext.create('Ext.data.Store', {
@@ -1310,7 +1310,7 @@ Ext.formbuilder.createElementForm = function () {
           columns: [{
             xtype: 'gridcolumn',
             dataIndex: 'value',
-            header: 'Functions',
+            header: Drupal.t('Functions'),
             sortable: true,
             flex: 1,
             field: {
@@ -1322,20 +1322,20 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'pre_render',
                 anchor: 'left',
-                html: '<h3><a name="pre_render" id="pre_render"></a>#pre_render</h3>' +
+                html: Drupal.t('<h3><a name="pre_render" id="pre_render"></a>#pre_render</h3>' +
               '<p><strong>Used by</strong>: All elements and forms.</p>' +
               '<p><strong>Description</strong>:' +
               'Function(s) to call <strong>before</strong>' +
               'rendering in </a><a href="http://api.drupal.org/api/function/drupal_render/" class="local">drupal_render</a>()' +
               'has occured. The function(s) provided in #pre_render receive the element as an argument and ' +
               'must return the altered element.</p>' +
-              '<p><strong>Values</strong>: An array of function names to call.</p>'
+              '<p><strong>Values</strong>: An array of function names to call.</p>')
               });
             }
           }
         }, {
           xtype: 'formgrid',
-          title: 'Post Render',
+          title: Drupal.t('Post Render'),
           id: 'post_render',
           name: 'post_render',
           store: Ext.create('Ext.data.Store', {
@@ -1353,7 +1353,7 @@ Ext.formbuilder.createElementForm = function () {
           columns: [{
             xtype: 'gridcolumn',
             dataIndex: 'value',
-            header: 'Functions',
+            header: Drupal.t('Functions'),
             sortable: true,
             flex: 1,
             field: {
@@ -1365,20 +1365,20 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'post_render',
                 anchor: 'left',
-                html: '<h3><a name="post_render" id="post_render"></a>#post_render</h3>' +
+                html: Drupal.t('<h3><a name="post_render" id="post_render"></a>#post_render</h3>' +
               '<p><strong>Used by</strong>: All elements and forms</p>' +
               '<p><strong>Description</strong>:' +
               'Function(s) to call <strong>after</strong>' +
               'rendering in </a><a href="http://api.drupal.org/api/function/drupal_render/" class="local">drupal_render</a>()' +
               'has occured. The named function is called with two arguments, the rendered element and its children. It returns the (potentially)' +
               'altered) element content.</p>' +
-              '<p><strong>Values</strong>: An array of function names to call.</p>'
+              '<p><strong>Values</strong>: An array of function names to call.</p>')
               });
             }
           }
         }, {
           xtype: 'formgrid',
-          title: 'After Build',
+          title: Drupal.t('After Build'),
           id: 'after_build',
           name: 'after_build',
           store: Ext.create('Ext.data.Store', {
@@ -1396,7 +1396,7 @@ Ext.formbuilder.createElementForm = function () {
           columns: [{
             xtype: 'gridcolumn',
             dataIndex: 'value',
-            header: 'Function',
+            header: Drupal.t('Function'),
             sortable: true,
             flex: 1,
             field: {
@@ -1408,9 +1408,9 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'after_build',
                 anchor: 'left',
-                html: '<h3><a name="after_build" id="after_build"></a>#after_build</h3>'+
+                html: Drupal.t('<h3><a name="after_build" id="after_build"></a>#after_build</h3>'+
               '<p><strong>Used by</strong>: All elements and forms</p>' +
-              '<p><strong>Description</strong>: An array of function names which will be called after the form or element is built.</p>'
+              '<p><strong>Description</strong>: An array of function names which will be called after the form or element is built.</p>')
               });
             }
           }
@@ -1418,7 +1418,7 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'formgrid',
           id: 'options',
           name: 'options',
-          title: 'Options',
+          title: Drupal.t('Options'),
           store: Ext.create('Ext.data.Store', {
             fields:['key', 'value'],
             proxy: {
@@ -1435,7 +1435,7 @@ Ext.formbuilder.createElementForm = function () {
           columns: [{
             xtype: 'gridcolumn',
             dataIndex: 'key',
-            header: 'Value',
+            header: Drupal.t('Value'),
             sortable: true,
             width: 100,
             field: {
@@ -1444,7 +1444,7 @@ Ext.formbuilder.createElementForm = function () {
           },{
             xtype: 'gridcolumn',
             dataIndex: 'value',
-            header: 'Label',
+            header: Drupal.t('Label'),
             sortable: true,
             flex: 1,
             field: {
@@ -1456,15 +1456,15 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'options',
                 anchor: 'left',
-                html: '<h3><a name="options" id="options"></a>#options</h3>' +
+                html: Drupal.t('<h3><a name="options" id="options"></a>#options</h3>' +
               '<p><strong>Used by</strong>: <a href="#checkboxes">checkboxes</a>, <a href="#radios">radios</a>, <a href="#select">select</a></p>' +
-              '<p><strong>Description</strong>: Selectable options for a form element that allows multiple choices.</p>'
+              '<p><strong>Description</strong>: Selectable options for a form element that allows multiple choices.</p>')
               });
             }
           }
         },  {
           xtype: 'formgrid',
-          title: 'User Data',
+          title: Drupal.t('User Data'),
           id: 'user_data',
           name: 'user_data',
           store: Ext.create('Ext.data.Store', {
@@ -1483,7 +1483,7 @@ Ext.formbuilder.createElementForm = function () {
           columns: [{
             xtype: 'gridcolumn',
             dataIndex: 'key',
-            header: 'Key',
+            header: Drupal.t('Key'),
             sortable: true,
             width: 150,
             field: {
@@ -1492,7 +1492,7 @@ Ext.formbuilder.createElementForm = function () {
           },{
             xtype: 'gridcolumn',
             dataIndex: 'value',
-            header: 'Value',
+            header: Drupal.t('Value'),
             sortable: true,
             flex: 1,
             field: {
@@ -1504,15 +1504,15 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'user_data',
                 anchor: 'left',
-                html: '<h3><a name="weightval" id="weightval"></a>#user_data</h3>' +
+                html: Drupal.t('<h3><a name="weightval" id="weightval"></a>#user_data</h3>' +
               ' <p><strong>Used by</strong>: Custom elements</p>' +
-              '<p><strong>Description</strong>: Used by custom form elements such as tabpanels. Consult documentation about what values can be specified here.</p>'
+              '<p><strong>Description</strong>: Used by custom form elements such as tabpanels. Consult documentation about what values can be specified here.</p>')
               });
             }
           }
         }, {
           xtype: 'formgrid',
-          title: 'Submit',
+          title: Drupal.t('Submit'),
           id: 'submit',
           name: 'submit',
           store: Ext.create('Ext.data.Store', {
@@ -1530,7 +1530,7 @@ Ext.formbuilder.createElementForm = function () {
           columns: [{
             xtype: 'gridcolumn',
             dataIndex: 'value',
-            header: 'Functions',
+            header: Drupal.t('Functions'),
             sortable: true,
             flex: 1,
             field: {
@@ -1542,16 +1542,16 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'submit',
                 anchor: 'left',
-                html: '<h3><a name="submit-prop" id="submit-prop"></a>#submit</h3>' +
+                html: Drupal.t('<h3><a name="submit-prop" id="submit-prop"></a>#submit</h3>' +
               '<p><strong>Used by</strong>: <a href="#button">button</a>, <a href="#form">form</a>, <a href="#image_button">image_button</a>, <a href="#submit">submit</a></p>' +
               '<p><strong>Description</strong>: Contains a list of submit callbacks to be excuted on the form or only when a specific button is clicked.</p>' +
-              '<p><strong>Values</strong>: An array of function names.</p>'
+              '<p><strong>Values</strong>: An array of function names.</p>')
               });
             }
           }
         }, {
           xtype: 'formgrid',
-          title: 'Validate',
+          title: Drupal.t('Validate'),
           id: 'validate',
           name: 'validate',
           store: Ext.create('Ext.data.Store', {
@@ -1569,7 +1569,7 @@ Ext.formbuilder.createElementForm = function () {
           columns: [{
             xtype: 'gridcolumn',
             dataIndex: 'value',
-            header: 'Functions',
+            header: Drupal.t('Functions'),
             sortable: true,
             flex: 1,
             field: {
@@ -1581,10 +1581,10 @@ Ext.formbuilder.createElementForm = function () {
               Ext.create('Ext.tip.ToolTip', {
                 target: 'validate',
                 anchor: 'left',
-                html: '<h3><a name="validate" id="validate"></a>#validate</h3>' +
+                html: Drupal.t('<h3><a name="validate" id="validate"></a>#validate</h3>' +
               '<p class="help"><strong>Used by</strong>: <a href="#button">button</a>, <a href="#image_button">image_button</a>, <a href="#form">form</a>, <a href="#submit">submit</a></p>' +
               '<p><strong>Description</strong>: A list of custom validation functions that need to be passed.This is usually used to add additional validation functions to a form, or to use an alternate function rather than the default form validation function which is the form ID with <em>_validate</em> appended to it.</p>' +
-              '<p><strong>Values</strong>: An array of function names.</p>'
+              '<p><strong>Values</strong>: An array of function names.</p>')
               });
             }
           }
@@ -1592,7 +1592,7 @@ Ext.formbuilder.createElementForm = function () {
       }]
     }],
     buttons: [{
-      text: 'Clear',
+      text: Drupal.t('Clear'),
       handler: function() {
         this.up('form').getForm().reset();
       }

--- a/builder/js/ElementForm.js
+++ b/builder/js/ElementForm.js
@@ -1233,7 +1233,7 @@ Ext.formbuilder.createElementForm = function () {
           columns: [{
             xtype: 'gridcolumn',
             dataIndex: 'value',
-            header: 'Function',
+            header: Drupal.t('Function'),
             sortable: true,
             flex: 1,
             field: {

--- a/builder/js/FormGrid.js
+++ b/builder/js/FormGrid.js
@@ -23,14 +23,14 @@ Ext.define('Form.Grid', {
       viewConfig: {
         plugins: {
           ptype: 'gridviewdragdrop',
-          dragText: 'Drag and drop to reorganize'
+          dragText: Drupal.t('Drag and drop to reorganize')
         }
       },
       dockedItems: [{
         xtype: 'toolbar',
         items: [{
           iconCls: 'icon-add',
-          text: 'Add',
+          text: Drupal.t('Add'),
           scope: this,
           handler: function() {
             var rec = Ext.ModelManager.create(me.modelInitTmpl, me.store.model.modelName);
@@ -41,7 +41,7 @@ Ext.define('Form.Grid', {
           }
         }, {
           iconCls: 'icon-delete',
-          text: 'Delete',
+          text: Drupal.t('Delete'),
           disabled: true,
           itemId: 'delete',
           scope: this,

--- a/builder/js/MainPanel.js
+++ b/builder/js/MainPanel.js
@@ -43,7 +43,7 @@ Ext.formbuilder.createMainPanel = function(children){
     return Ext.create('Ext.panel.Panel', {
         width: 960,
         height: 820,
-        title: 'Form Editor',
+        title: Drupal.t('Form Editor'),
         layout: 'border',
         renderTo: 'xml-form-builder-editor',
         items: children,
@@ -55,7 +55,7 @@ Ext.formbuilder.createMainPanel = function(children){
             xtype: 'toolbar',
             items: [{
                 xtype: 'button',
-                text: 'Form Properties',
+                text: Drupal.t('Form Properties'),
                 handler: function() {
                     Ext.formbuilder.showPropertiesForm();
                 }
@@ -63,7 +63,7 @@ Ext.formbuilder.createMainPanel = function(children){
                 xtype: 'tbfill'
             },{
                 xtype: 'button',
-                text: 'Save & Preview',
+                text: Drupal.t('Save & Preview'),
                 handler: function() {
                     Ext.formbuilder.save(true);
                 }
@@ -71,7 +71,7 @@ Ext.formbuilder.createMainPanel = function(children){
                 xtype: 'tbseparator'
             },{
                 xtype: 'button',
-                text: 'Save',
+                text: Drupal.t('Save'),
                 handler: function() {
                     Ext.formbuilder.save(false);
                 }

--- a/builder/js/PreviewPanel.js
+++ b/builder/js/PreviewPanel.js
@@ -8,7 +8,7 @@
  */
 Ext.formbuilder.getPreviewURL = function(url) {
     var view_url = url.replace(/\/edit/i, '/view');
-    return "<iframe src='" + view_url + "' width='100%' height='100%'><p>Your browser does not support iframes.</p></iframe>";
+    return "<iframe src='" + view_url + "' width='100%' height='100%'><p>" + Drupal.t('Your browser does not support iframes.') + "</p></iframe>";
 }
 /**
  * 
@@ -16,7 +16,7 @@ Ext.formbuilder.getPreviewURL = function(url) {
 Ext.formbuilder.createPreviewPanel =  function(url) { // Use an iframe...
     var preview = Ext.formbuilder.getPreviewURL(url);
     return Ext.create('Ext.form.Panel', {
-        title: 'Preview',
+        title: Drupal.t('Preview'),
         html: preview
     });
 };

--- a/builder/js/PropertiesForm.js
+++ b/builder/js/PropertiesForm.js
@@ -8,40 +8,40 @@
  */
 Ext.formbuilder.createPropertiesForm = function() {
     return Ext.create('Ext.form.Panel', {
-        title: 'Properties Form',
+        title: Drupal.t('Properties Form'),
         region: 'center',
         margin: '1 1 1 0',
         frame: true,
         items:  [{
             xtype: 'fieldset',
-            title: 'Root Element',
+            title: Drupal.t('Root Element'),
             items: [{
                 xtype: 'textfield',
                 id: 'localName',
                 name: 'localName',
-                fieldLabel: 'Root Element Name',
+                fieldLabel: Drupal.t('Root Element Name'),
                 allowBlank: false,
                 anchor: '100%'
             },{
                 xtype: 'textfield',
                 id: 'uri',
                 name: 'uri',
-                fieldLabel: 'Namespace URI',
+                fieldLabel: Drupal.t('Namespace URI'),
                 anchor: '100%'
             }]
         },{
             xtype: 'fieldset',
-            title: 'Schema',
+            title: Drupal.t('Schema'),
             items: [{
                 xtype: 'textfield',
                 id: 'schema',
                 name: 'schema',
-                fieldLabel: 'Name',
+                fieldLabel: Drupal.t('Name'),
                 anchor: '100%'
             }]
         },{
             xtype: 'formgrid',
-            title: 'Namespaces',
+            title: Drupal.t('Namespaces'),
             id: 'namespaces',
             name: 'namespaces',
             height: 300,
@@ -53,7 +53,7 @@ Ext.formbuilder.createPropertiesForm = function() {
             columns: [{
                 xtype: 'gridcolumn',
                 dataIndex: 'key',
-                header: 'Prefix',
+                header: Drupal.t('Prefix'),
                 sortable: true,
                 width: 150,
                 field: {
@@ -62,7 +62,7 @@ Ext.formbuilder.createPropertiesForm = function() {
             },{
                 xtype: 'gridcolumn',
                 dataIndex: 'value',
-                header: 'URI',
+                header: Drupal.t('URI'),
                 sortable: true,
                 flex: 1,
                 field: {

--- a/builder/js/TreePanel.js
+++ b/builder/js/TreePanel.js
@@ -10,7 +10,7 @@ Ext.formbuilder.createTreePanel = function() {
         ptype: 'treeviewdragdrop'
       }
     },
-    title: 'Elements',
+    title: Drupal.t('Elements'),
     store: this.elementStore,
     region: 'west',
     width: 230,
@@ -22,7 +22,7 @@ Ext.formbuilder.createTreePanel = function() {
       xtype: 'toolbar',
       items: [{
         xtype: 'button',
-        text: 'Add',
+        text: Drupal.t('Add'),
         handler: function() {
           var tree = Ext.formbuilder.treePanel;
           var selectionModel = tree.getSelectionModel();
@@ -40,7 +40,7 @@ Ext.formbuilder.createTreePanel = function() {
         }
       }, {
         xtype: 'button',
-        text: 'Copy',
+        text: Drupal.t('Copy'),
         handler: function() {
           var tree = Ext.formbuilder.treePanel;
           var selectionModel = tree.getSelectionModel();
@@ -51,7 +51,7 @@ Ext.formbuilder.createTreePanel = function() {
         }
       }, {
         xtype: 'button',
-        text: 'Paste',
+        text: Drupal.t('Paste'),
         handler: function() {
           var tree = Ext.formbuilder.treePanel;
           var selectionModel = tree.getSelectionModel();
@@ -68,7 +68,7 @@ Ext.formbuilder.createTreePanel = function() {
         }
       }, {
         xtype: 'button',
-        text: 'Delete',
+        text: Drupal.t('Delete'),
         handler: function() {
           var tree = Ext.formbuilder.treePanel;
           var selectionModel = tree.getSelectionModel();


### PR DESCRIPTION
The list of properties examined is:
- title
- fieldLabel
- html

Might want to look at how the markup is handled for tool tips gets handled at some point.
