### PR TITLE
Fix tab element styling with CSS aggregation enabled

### DIFF
--- a/elements/includes/Element.inc
+++ b/elements/includes/Element.inc
@@ -44,7 +44,9 @@ class Element {
    *   An list of files to be included from the jquery theme. Or a single file name.
    */
   public static function addUIThemeStyles($files = array()) {
-    self::addFiles('drupal_add_css', PATH_XML_FORM_ELEMENTS_JQUERY_THEME, $files, 'theme');
+    self::addFiles('drupal_add_css', PATH_XML_FORM_ELEMENTS_JQUERY_THEME, $files, array(
+      'group' => CSS_THEME,
+    ));
   }
 
   /**
@@ -62,7 +64,9 @@ class Element {
    * @param type $files
    */
   public static function addCSS($files = array()) {
-    self::addFiles('drupal_add_css', PATH_XML_FORM_ELEMENTS_CSS, $files, 'theme');
+    self::addFiles('drupal_add_css', PATH_XML_FORM_ELEMENTS_CSS, $files, array(
+      'group' => CSS_THEME,
+    ));
   }
 
   /**
@@ -76,7 +80,8 @@ class Element {
    *   The file(s) to be added.
    */
   private static function addFiles($function, $path, $files = array(), $additional_argument = NULL) {
-    $files = is_array($files) ? $files : array($files); // Convert string to array if needed.
+    // Convert string to array.
+    $files = (array)$files;
     foreach ($files as $file) {
       $function($path . $file, $additional_argument);
     }

--- a/elements/includes/Tabs.inc
+++ b/elements/includes/Tabs.inc
@@ -14,10 +14,10 @@ class Tabs {
    * @staticvar boolean $load
    *   Keeps us from loading the same files multiple times, while not required it just saves some time.
    */
-  public static function addRequiredResources() {
+  public static function addRequiredResources(array &$form_state) {
     static $load = TRUE;
     if ($load) {
-      module_load_include('inc', 'xml_form_elements', 'includes/Element');
+      form_load_include($form_state, 'inc', 'xml_form_elements', 'includes/Element');
       Element::addRequiredResources();
       Element::addUIWidgets('ui.tabs');
       Element::addUIThemeStyles(array('ui.core.css', 'ui.tabs.css', 'ui.theme.css'));
@@ -35,7 +35,7 @@ class Tabs {
    * @param array $complete_form
    */
   public static function process(array $element, array &$form_state, array $complete_form = NULL) {
-    self::addRequiredResources();
+    self::addRequiredResources($form_state);
     $element['#prefix'] = "<div class='clear-block' id='{$element['#hash']}'>";
     $element['#suffix'] = '</div>';
     return $element;


### PR DESCRIPTION
Use of Drupal 6 syntax for drupal_add_css() was causing issues.
Made to use the Drupal 7 syntax properly seems to have cleared it up.
