### PR TITLE
Can now backtrack and change a form selection.

### DIFF
--- a/builder/includes/ingest.form.inc
+++ b/builder/includes/ingest.form.inc
@@ -20,6 +20,8 @@
  */
 function xml_form_builder_ingest_form(array $form, array &$form_state, array $association) {
   form_load_include($form_state, 'inc', 'xml_form_builder', 'ingest.form');
+  $step_storage = &islandora_ingest_form_get_step_storage($form_state, 'xml_form_builder_metadata_step');
+  $step_storage['association'] = $association;
   $form_name = $association['form_name'];
   $dsid = $association['dsid'];
   $object = islandora_ingest_form_get_object($form_state);
@@ -35,6 +37,22 @@ function xml_form_builder_ingest_form(array $form, array &$form_state, array $as
 }
 
 /**
+ * Alter the form such that previous will unset any stored form.
+ */
+function xml_form_builder_form_xml_form_builder_ingest_form_alter(array &$form, array &$form_state) {
+  array_unshift($form['prev']['#submit'], 'xml_form_builder_ingest_form_previous_submit');
+}
+
+/**
+ * Unset the form storage.
+ */
+function xml_form_builder_ingest_form_previous_submit(array $form, array &$form_state) {
+  unset($form_state['storage'][FormStorage::STORAGE_ROOT]);
+  $step_storage = &islandora_ingest_form_get_step_storage($form_state, 'xml_form_builder_metadata_step');
+  unset($step_storage['values']);
+}
+
+/**
  * Updates the ingestable object's datastream.
  *
  * @param array $form
@@ -43,14 +61,14 @@ function xml_form_builder_ingest_form(array $form, array &$form_state, array $as
  *   The Drupal form state.
  */
 function xml_form_builder_ingest_form_submit(array $form, array &$form_state) {
-  $metadata_step_storage = &islandora_ingest_form_get_step_storage($form_state, 'xml_form_builder_metadata_step');
-  $association = $metadata_step_storage['association'];
+  $step_storage = &islandora_ingest_form_get_step_storage($form_state, 'xml_form_builder_metadata_step');
+  $association = $step_storage['association'];
   $object = islandora_ingest_form_get_object($form_state);
   $xml_form = new XMLForm($form_state);
   $document = $xml_form->submit($form, $form_state);
   $title_field = drupal_array_get_nested_value($form, $association['title_field']);
   $label = $title_field['#value'];
-  $metadata_step_storage['created'] = xml_form_builder_update_object($object, $association, $document, $label);
+  $step_storage['created'] = xml_form_builder_update_object($object, $association, $document, $label);
 }
 
 /**
@@ -62,12 +80,13 @@ function xml_form_builder_ingest_form_submit(array $form, array &$form_state) {
  *   The Drupal form state.
  */
 function xml_form_builder_ingest_form_undo_submit(array $form, array &$form_state) {
-  $metadata_step_storage = &islandora_ingest_form_get_step_storage($form_state, 'xml_form_builder_metadata_step');
+  $step_storage = &islandora_ingest_form_get_step_storage($form_state, 'xml_form_builder_metadata_step');
   $object = islandora_ingest_form_get_object($form_state);
-  foreach ($metadata_step_storage['created'] as $dsid => $created) {
+  foreach ($step_storage['created'] as $dsid => $created) {
     if ($created) {
       $object->purgeDatastream($dsid);
     }
   }
-  unset($metadata_step_storage['created']);
+  unset($step_storage['created']);
+  unset($step_storage['association']);
 }

--- a/builder/includes/ingest.form.inc
+++ b/builder/includes/ingest.form.inc
@@ -40,7 +40,9 @@ function xml_form_builder_ingest_form(array $form, array &$form_state, array $as
  * Alter the form such that previous will unset any stored form.
  */
 function xml_form_builder_form_xml_form_builder_ingest_form_alter(array &$form, array &$form_state) {
-  array_unshift($form['prev']['#submit'], 'xml_form_builder_ingest_form_previous_submit');
+  if (isset($form['prev']['#submit'])) {
+    array_unshift($form['prev']['#submit'], 'xml_form_builder_ingest_form_previous_submit');
+  }
 }
 
 /**

--- a/builder/includes/select_association.form.inc
+++ b/builder/includes/select_association.form.inc
@@ -165,12 +165,8 @@ function xml_form_builder_select_association_form_value_callback(array $element,
  *   The Drupal form state.
  */
 function xml_form_builder_select_association_form_submit(array $form, array &$form_state) {
-  $shared_storage = &islandora_ingest_form_get_shared_storage($form_state);
   $association_step_storage = &islandora_ingest_form_get_step_storage($form_state, 'xml_form_builder_association_step');
-  $metadata_step_storage = &islandora_ingest_form_get_step_storage($form_state, 'xml_form_builder_metadata_step');
-  $association = $form_state['values']['association'];
-  // Store the selected association in both the association/metadata steps.
-  $association_step_storage['association'] = $metadata_step_storage['association'] = $association;
+  $association_step_storage['association'] = $form_state['values']['association'];
 }
 
 /**
@@ -183,8 +179,5 @@ function xml_form_builder_select_association_form_submit(array $form, array &$fo
  */
 function xml_form_builder_select_association_form_undo_submit(array $form, array &$form_state) {
   $association_step_storage = &islandora_ingest_form_get_step_storage($form_state, 'xml_form_builder_association_step');
-  $metadata_step_storage = &islandora_ingest_form_get_step_storage($form_state, 'xml_form_builder_metadata_step');
-  // Forget the selected association.
   unset($association_step_storage['association']);
-  unset($metadata_step_storage['association']);
 }

--- a/builder/xml_form_builder.module
+++ b/builder/xml_form_builder.module
@@ -385,10 +385,11 @@ function xml_form_builder_theme() {
 function xml_form_builder_islandora_ingest_steps(array &$form_state) {
   module_load_include('inc', 'xml_form_builder', 'includes/associations');
   $shared_storage = islandora_ingest_form_get_shared_storage($form_state);
-  $metadata_step_storage = &islandora_ingest_form_get_step_storage($form_state, 'xml_form_builder_metadata_step');
   $association_step_storage = &islandora_ingest_form_get_step_storage($form_state, 'xml_form_builder_association_step');
   $associations = xml_form_builder_get_associations(array(), $shared_storage['models'], array());
-  $metadata_step_storage['association'] = isset($metadata_step_storage['association']) ? $metadata_step_storage['association'] : current($associations);
+  // If the user has selected association use that one, otherwise assume there
+  // is only one association.
+  $association = isset($association_step_storage['association']) ? $association_step_storage['association'] : reset($associations);
   $num_associations = count($associations);
   $select_association_step = ($num_associations > 1) ? array(
     'weight' => 0,
@@ -397,15 +398,15 @@ function xml_form_builder_islandora_ingest_steps(array &$form_state) {
     'module' => 'xml_form_builder',
     'file' => 'includes/select_association.form.inc',
     'args' => array($associations),
-      ) : NULL;
+  ) : NULL;
   $metadata_step = ($num_associations >= 1) ? array(
     'weight' => 5,
     'type' => 'form',
     'form_id' => 'xml_form_builder_ingest_form',
     'module' => 'xml_form_builder',
     'file' => 'includes/ingest.form.inc',
-    'args' => array($metadata_step_storage['association']),
-      ) : NULL;
+    'args' => array($association),
+  ) : NULL;
   return array(
     'xml_form_builder_association_step' => $select_association_step,
     'xml_form_builder_metadata_step' => $metadata_step,


### PR DESCRIPTION
Form Builder saves its entire state in:
$form_state['storage']['objective_form_storage']

This now gets unset when the previous button is pressed, allowing for other
forms to be selected. Also we unset the saved values as a different form
can be presented to the user than the original so retaining the old values
doesn't make much sense.
