### PR TITLE
Output better XML using cleanup_mods.xsl

### DIFF
--- a/builder/self_transforms/cleanup_mods.xsl
+++ b/builder/self_transforms/cleanup_mods.xsl
@@ -2,10 +2,11 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" media-type="text/xml"/>
 <xsl:strip-space elements="*"/>
+<xsl:template match="*[not(node())]"/>    
 <xsl:template match="node()|@*">
     <xsl:copy>
-        <xsl:apply-templates select="node()|@*"/>
+        <xsl:apply-templates select="node()[normalize-space()]|@*[normalize-space()]"/>
     </xsl:copy>
 </xsl:template>
-<xsl:template match="*[normalize-space(.)=''][normalize-space(@*)='']"/>
 </xsl:stylesheet>
+


### PR DESCRIPTION
Changes originally from Caitlin Nelson of FLVC.  Removes empty attributes, empty elements, and elements containing only attributes.
