### PR TITLE
Fixes the issue with image path to ‘add.png’ breaking when i18n site pre...

### DIFF
--- a/elements/includes/Tags.inc
+++ b/elements/includes/Tags.inc
@@ -143,7 +143,7 @@ class Tags {
 function template_preprocess_tags(&$vars) {
   global $base_url;
   $tags = &$vars['element'];
-  $vars['image_path'] =  $base_url . '/' . PATH_XML_FORM_ELEMENTS_IMAGES; // Location of images/  
+  $vars['image_path'] =  $base_url . '/' . PATH_XML_FORM_ELEMENTS_IMAGES; // Location of images.  
   $vars['add'] = $tags['controls']['add']; // Visible Add Button
   $vars['edit'] = isset($tags['controls']['edit']) ? $tags['controls']['edit'] : NULL; // Hidden Edit Button
   $vars['remove'] = isset($tags['controls']['remove']) ? $tags['controls']['remove'] : NULL; // Hidden Remove Button

--- a/elements/includes/Tags.inc
+++ b/elements/includes/Tags.inc
@@ -141,8 +141,9 @@ class Tags {
  * @param array $vars
  */
 function template_preprocess_tags(&$vars) {
+  global $base_url;
   $tags = &$vars['element'];
-  $vars['image_path'] = url(XML_FORM_ELEMENTS_IMAGES_PATH); // Location of images.
+  $vars['image_path'] =  $base_url . '/' . PATH_XML_FORM_ELEMENTS_IMAGES; // Location of images/  
   $vars['add'] = $tags['controls']['add']; // Visible Add Button
   $vars['edit'] = isset($tags['controls']['edit']) ? $tags['controls']['edit'] : NULL; // Hidden Edit Button
   $vars['remove'] = isset($tags['controls']['remove']) ? $tags['controls']['remove'] : NULL; // Hidden Remove Button


### PR DESCRIPTION
...site prefixes are in use. url() should not be used to get file paths. This is a documented issue, fix found here: https://api.drupal.org/comment/26869#comment-26869 . Note that the “better” solution in the comment following is not actually better - it does not work when Drupal is installed in a subdirectory and not in the server’s root.
