### PR TITLE
Fixed problem where empty dc:subjects could be output

### DIFF
--- a/builder/transforms/mods_to_dc.xsl
+++ b/builder/transforms/mods_to_dc.xsl
@@ -111,15 +111,17 @@
 	</xsl:template>
 
 	<xsl:template match="mods:subject[mods:topic | mods:name | mods:occupation | mods:geographic | mods:hierarchicalGeographic | mods:cartographics | mods:temporal] ">
-		<dc:subject>
-			<xsl:for-each select="mods:topic | mods:occupation">
-				<xsl:value-of select="."/>
-				<xsl:if test="position()!=last()">--</xsl:if>
-			</xsl:for-each>
-			<xsl:for-each select="mods:name">
-				<xsl:call-template name="name"/>
-			</xsl:for-each>
-		</dc:subject>
+		<xsl:if test="mods:topic | mods:occupation | mods:name">
+			<dc:subject>
+				<xsl:for-each select="mods:topic | mods:occupation">
+					<xsl:value-of select="."/>
+					<xsl:if test="position()!=last()">--</xsl:if>
+				</xsl:for-each>
+				<xsl:for-each select="mods:name">
+					<xsl:call-template name="name"/>
+				</xsl:for-each>
+			</dc:subject>
+		</xsl:if>
 
 		<xsl:for-each select="mods:titleInfo/mods:title">
 			<dc:subject>


### PR DESCRIPTION
In a MODS record with mods:hierarchical but not mods:topic, empty dc:subject elements are created because "dc:subject" is output without first checking whether mods:topic, mods:occupation, or mods:name exist.

This PR just adds a check for mods:topic, mods:occupation, or mods:name before it outputs the dc:subject
