### PR TITLE
7.x defaults and fixes

### DIFF
--- a/builder/xml_form_builder.module
+++ b/builder/xml_form_builder.module
@@ -701,6 +701,10 @@ function xml_form_builder_settings_form(array $form, array &$form_state) {
       '#default_value' => variable_get('xml_form_builder_use_default_dc_xslts', FALSE),
     ),
   );
+  // Fix for static variables
+  $modification_options = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$modification_options);
+  $commercial_options = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$commercial_options);
+  $countries = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$countries);
   $form['xml_form_builder_cc_fieldset'] = array(
     '#type' => 'fieldset',
     '#title' => t('Creative Commons defaults'),
@@ -708,19 +712,19 @@ function xml_form_builder_settings_form(array $form, array &$form_state) {
     'xml_form_builder_cc_default_allow_derivatives' => array(
       '#type' => 'select',
       '#title' => t('Allow modifications of your work?'),
-      '#options' => CreativeCommons::$modification_options,
+      '#options' => $modification_options,
       '#default_value' => variable_get('xml_form_builder_cc_default_allow_derivatives', 'y'),
     ),
     'xml_form_builder_cc_default_allow_commercial' => array(
       '#type' => 'select',
       '#title' => t('Allow commercial uses of your work?'),
-      '#options' => CreativeCommons::$commercial_options,
+      '#options' => $commercial_options,
       '#default_value' => variable_get('xml_form_builder_cc_default_allow_commercial', 'y'),
     ),
     'xml_form_builder_cc_default_jurisdiction' => array(
       '#type' => 'select',
       '#title' => t('License Jurisdiction.'),
-      '#options' => CreativeCommons::$countries,
+      '#options' => $countries,
       '#default_value' => variable_get('xml_form_builder_cc_default_jurisdiction', 'international'),
     ),
   );

--- a/builder/xml_form_builder.module
+++ b/builder/xml_form_builder.module
@@ -701,10 +701,10 @@ function xml_form_builder_settings_form(array $form, array &$form_state) {
       '#default_value' => variable_get('xml_form_builder_use_default_dc_xslts', FALSE),
     ),
   );
-  // Fix for static variables
-  $modification_options = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$modification_options);
-  $commercial_options = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$commercial_options);
-  $countries = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$countries);
+  // Fix for static variables.
+  $modification_options = array_map(array('CreativeCommons', 'xmlFormBuilderFixVariables'), CreativeCommons::$modificationOptions);
+  $commercial_options = array_map(array('CreativeCommons', 'xmlFormBuilderFixVariables'), CreativeCommons::$commercialOptions);
+  $countries = array_map(array('CreativeCommons', 'xmlFormBuilderFixVariables'), CreativeCommons::$countries);
   $form['xml_form_builder_cc_fieldset'] = array(
     '#type' => 'fieldset',
     '#title' => t('Creative Commons defaults'),

--- a/builder/xml_form_builder.module
+++ b/builder/xml_form_builder.module
@@ -692,6 +692,7 @@ function xml_form_builder_transform_mods_collection_hack(DOMDocument $document) 
  *   The form definition.
  */
 function xml_form_builder_settings_form(array $form, array &$form_state) {
+  form_load_include($form_state, 'inc', 'xml_form_elements', 'includes/creative_commons');
   $form = array(
     'xml_form_builder_use_default_dc_xslts' => array(
       '#type' => 'checkbox',
@@ -700,6 +701,30 @@ function xml_form_builder_settings_form(array $form, array &$form_state) {
       '#default_value' => variable_get('xml_form_builder_use_default_dc_xslts', FALSE),
     ),
   );
+  $form['xml_form_builder_cc_fieldset'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Creative Commons defaults'),
+    '#description' => t('Set defaults for use in the Creative Commons field when adding new objects.'),
+    'xml_form_builder_cc_default_allow_derivatives' => array(
+      '#type' => 'select',
+      '#title' => t('Allow modifications of your work?'),
+      '#options' => CreativeCommons::$modification_options,
+      '#default_value' => variable_get('xml_form_builder_cc_default_allow_derivatives', 'y'),
+    ),
+    'xml_form_builder_cc_default_allow_commercial' => array(
+      '#type' => 'select',
+      '#title' => t('Allow commercial uses of your work?'),
+      '#options' => CreativeCommons::$commercial_options,
+      '#default_value' => variable_get('xml_form_builder_cc_default_allow_commercial', 'y'),
+    ),
+    'xml_form_builder_cc_default_jurisdiction' => array(
+      '#type' => 'select',
+      '#title' => t('License Jurisdiction.'),
+      '#options' => CreativeCommons::$countries,
+      '#default_value' => variable_get('xml_form_builder_cc_default_jurisdiction', 'international'),
+    ),
+  );
+
   return system_settings_form($form);
 }
 

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -96,7 +96,6 @@ class CreativeCommons {
       $license_output_id = $form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'];
     }
     else {
-      // $license_output_id = drupal_html_id('license_output');
       $license_output_id = 'license_output';
       $form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'] = $license_output_id;
     }

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -8,8 +8,6 @@
 
 class CreativeCommons {
 
-
-
   public static $modificationOptions = array(
     'y' => 'Yes',
     'n' => 'No',
@@ -91,7 +89,7 @@ class CreativeCommons {
    * @return array
    *   The element definition.
    */
-    public static function xmlFormElementsCreativeCommons($element, &$form_state) {
+  public static function xmlFormElementsCreativeCommons($element, &$form_state) {
 
     // Get an ID for ajax.
     if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'])) {
@@ -284,14 +282,13 @@ class CreativeCommons {
   }
 
   /**
-   * Static class variables can't be defined with the t(), 
-   * so this allows us to add it after the fact using array_walk.
+   * Static class variables can't be defined with the t().
    *
    * @param string $value
-   *    array value to apply t() to
+   *  array value to apply t() to
    *
    * @return string
-   *    the t() modified string
+   *  the t() modified string
    */
   public static function xmlFormBuilderFixVariables($value) {
     return t('%t', array('%t' => $value));

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -107,7 +107,14 @@ public static function xml_form_elements_creative_commons($element, &$form_state
   if (!isset($form_state['input'][$element['#name']]) && isset($element['#default_value'])) {
     // Reversing this array facilitates value_callback mangling by community.
     $default_value_array = array_reverse(explode('/', $element['#default_value']));
-    $properties = explode('-', $default_value_array[3]);
+    // If there are only 3 elements, country is blank = international.
+    if (count($default_value_array) == 3) {
+      $default_keys = array('property' => 2);
+    }
+    else {
+      $default_keys = array('jurisdiction' => 1, 'property' => 3);
+    }
+    $properties = explode('-', $default_value_array[$default_keys['property']]);
 
     $commercial = variable_get('xml_form_builder_cc_default_allow_commercial', 'y');
     $derivatives = variable_get('xml_form_builder_cc_default_allow_derivatives', 'y');
@@ -131,7 +138,12 @@ public static function xml_form_elements_creative_commons($element, &$form_state
       }
     }
 
-    $jurisdiction = empty($default_value_array[1]) ? variable_get('xml_form_builder_cc_default_jurisdiction', 'international') : $default_value_array[1];
+    if (array_key_exists('jurisdiction', $default_keys)) {
+      $jurisdiction = empty($default_value_array[$default_keys['jurisdiction']]) ? variable_get('xml_form_builder_cc_default_jurisdiction', 'international') : $default_value_array[$default_keys['jurisdiction']];
+    }
+    else {
+      $jurisdiction = 'international';
+    }
   }
   else {
     $derivatives = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_modifications']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_modifications'] : variable_get('xml_form_builder_cc_default_allow_derivatives', 'y');

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -285,10 +285,10 @@ class CreativeCommons {
    * Static class variables can't be defined with the t().
    *
    * @param string $value
-   *  array value to apply t() to
+   *   array value to apply t() to
    *
    * @return string
-   *  the t() modified string
+   *   the t() modified string
    */
   public static function xmlFormBuilderFixVariables($value) {
     return t('%t', array('%t' => $value));

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -9,8 +9,8 @@
 class CreativeCommons {
 
 
-  
-  public static $modification_options = array(
+
+  public static $modificationOptions = array(
     'y' => 'Yes',
     'n' => 'No',
     'sa' => 'Yes, as long as others share alike',
@@ -78,7 +78,7 @@ class CreativeCommons {
     'vn' => 'Vietnam',
   );
 
-  public static $commercial_options = array(
+  public static $commercialOptions = array(
     'y' => 'Yes',
     'n' => 'No',
   );
@@ -91,14 +91,14 @@ class CreativeCommons {
    * @return array
    *   The element definition.
    */
-  public static function xml_form_elements_creative_commons($element, &$form_state) {
+    public static function xmlFormElementsCreativeCommons($element, &$form_state) {
 
     // Get an ID for ajax.
     if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'])) {
       $license_output_id = $form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'];
     }
     else {
-      # $license_output_id = drupal_html_id('license_output');
+      // $license_output_id = drupal_html_id('license_output');
       $license_output_id = 'license_output';
       $form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'] = $license_output_id;
     }
@@ -151,10 +151,10 @@ class CreativeCommons {
       $jurisdiction = isset($form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction']) ? $form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction'] : variable_get('xml_form_builder_cc_default_jurisdiction', 'international');
     }
 
-    // Fix for static variables
-    $modification_options = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$modification_options);
-    $commercial_options = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$commercial_options);
-    $countries = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$countries);
+    // Fix for static variables.
+    $modification_options = array_map(array('CreativeCommons', 'xmlFormBuilderFixVariables'), CreativeCommons::$modificationOptions);
+    $commercial_options = array_map(array('CreativeCommons', 'xmlFormBuilderFixVariables'), CreativeCommons::$commercialOptions);
+    $countries = array_map(array('CreativeCommons', 'xmlFormBuilderFixVariables'), CreativeCommons::$countries);
 
     // Form elements.
     $element['license_fieldset'] = array(
@@ -206,7 +206,7 @@ class CreativeCommons {
       $element['#tree'] = FALSE;
     }
 
-    $response = CreativeCommons::xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction);
+    $response = CreativeCommons::xmlFormElementsGetCreativeCommons($commercial, $derivatives, $jurisdiction);
     if ($response) {
       $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = (string) $response->{'license-uri'};
       $element['license_fieldset']['license_output'] = array(
@@ -216,7 +216,7 @@ class CreativeCommons {
       );
     }
     else {
-      $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = CreativeCommons::xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction);
+      $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = CreativeCommons::xmlFormElementsCreativeCommonsValue($commercial, $derivatives, $jurisdiction);
       $element['license_fieldset']['license_output'] = array();
     }
 
@@ -239,7 +239,7 @@ class CreativeCommons {
    *   SimpleXMLElement the return from the REST API.
    *   FALSE if failed request.
    */
-  public static function xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction) {
+  public static function xmlFormElementsGetCreativeCommons($commercial, $derivatives, $jurisdiction) {
     $response = drupal_http_request(url(
       'http://api.creativecommons.org/rest/1.5/license/standard/get',
       array(
@@ -269,7 +269,7 @@ class CreativeCommons {
    * @return string
    *   The value of the element.
    */
-  public static function xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction) {
+  public static function xmlFormElementsCreativeCommonsValue($commercial, $derivatives, $jurisdiction) {
     $arguments = '';
     if ($commercial == 'n') {
       $arguments = "$arguments-nc";
@@ -293,8 +293,8 @@ class CreativeCommons {
    * @return string
    *    the t() modified string
    */
-  public static function xml_form_builder_fix_variables($value) {
-    return t($value);
+  public static function xmlFormBuilderFixVariables($value) {
+    return t('%t', array('%t' => $value));
   }
 }
 

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -82,229 +82,229 @@ class CreativeCommons {
     'y' => 'Yes',
     'n' => 'No',
   );
-/**
- * Creates a creative_commons form element.
- *
- * @param array $form_state
- *   The form state.
- *
- * @return array
- *   The element definition.
- */
-public static function xml_form_elements_creative_commons($element, &$form_state) {
+  /**
+   * Creates a creative_commons form element.
+   *
+   * @param array $form_state
+   *   The form state.
+   *
+   * @return array
+   *   The element definition.
+   */
+  public static function xml_form_elements_creative_commons($element, &$form_state) {
 
-  // Get an ID for ajax.
-  if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'])) {
-    $license_output_id = $form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'];
-  }
-  else {
-    # $license_output_id = drupal_html_id('license_output');
-    $license_output_id = 'license_output';
-    $form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'] = $license_output_id;
-  }
-
-  // Figure out license state.
-  if (!isset($form_state['input'][$element['#name']]) && isset($element['#default_value'])) {
-    // Reversing this array facilitates value_callback mangling by community.
-    $default_value_array = array_reverse(explode('/', $element['#default_value']));
-    // If there are only 3 elements, country is blank = international.
-    if (count($default_value_array) == 3) {
-      $default_keys = array('property' => 2);
+    // Get an ID for ajax.
+    if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'])) {
+      $license_output_id = $form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'];
     }
     else {
-      $default_keys = array('jurisdiction' => 1, 'property' => 3);
+      # $license_output_id = drupal_html_id('license_output');
+      $license_output_id = 'license_output';
+      $form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'] = $license_output_id;
     }
-    $properties = explode('-', $default_value_array[$default_keys['property']]);
 
-    $commercial = variable_get('xml_form_builder_cc_default_allow_commercial', 'y');
-    $derivatives = variable_get('xml_form_builder_cc_default_allow_derivatives', 'y');
+    // Figure out license state.
+    if (!isset($form_state['input'][$element['#name']]) && isset($element['#default_value'])) {
+      // Reversing this array facilitates value_callback mangling by community.
+      $default_value_array = array_reverse(explode('/', $element['#default_value']));
+      // If there are only 3 elements, country is blank = international.
+      if (count($default_value_array) == 3) {
+        $default_keys = array('property' => 2);
+      }
+      else {
+        $default_keys = array('jurisdiction' => 1, 'property' => 3);
+      }
+      $properties = explode('-', $default_value_array[$default_keys['property']]);
 
-    foreach ($properties as $property) {
-      switch ($property) {
-        case 'by':
-          break;
+      $commercial = variable_get('xml_form_builder_cc_default_allow_commercial', 'y');
+      $derivatives = variable_get('xml_form_builder_cc_default_allow_derivatives', 'y');
 
-        case 'nc':
-          $commercial = 'n';
-          break;
+      foreach ($properties as $property) {
+        switch ($property) {
+          case 'by':
+            break;
 
-        case 'nd':
-          $derivatives = 'n';
-          break;
+          case 'nc':
+            $commercial = 'n';
+            break;
 
-        case 'sa':
-          $derivatives = 'sa';
-          break;
+          case 'nd':
+            $derivatives = 'n';
+            break;
+
+          case 'sa':
+            $derivatives = 'sa';
+            break;
+        }
+      }
+
+      if (array_key_exists('jurisdiction', $default_keys)) {
+        $jurisdiction = empty($default_value_array[$default_keys['jurisdiction']]) ? variable_get('xml_form_builder_cc_default_jurisdiction', 'international') : $default_value_array[$default_keys['jurisdiction']];
+      }
+      else {
+        $jurisdiction = 'international';
       }
     }
+    else {
+      $derivatives = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_modifications']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_modifications'] : variable_get('xml_form_builder_cc_default_allow_derivatives', 'y');
+      $commercial = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_commercial']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_commercial'] : variable_get('xml_form_builder_cc_default_allow_commercial', 'y');
+      $jurisdiction = isset($form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction']) ? $form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction'] : variable_get('xml_form_builder_cc_default_jurisdiction', 'international');
+    }
 
-    if (array_key_exists('jurisdiction', $default_keys)) {
-      $jurisdiction = empty($default_value_array[$default_keys['jurisdiction']]) ? variable_get('xml_form_builder_cc_default_jurisdiction', 'international') : $default_value_array[$default_keys['jurisdiction']];
+    // Fix for static variables
+    $modification_options = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$modification_options);
+    $commercial_options = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$commercial_options);
+    $countries = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$countries);
+
+    // Form elements.
+    $element['license_fieldset'] = array(
+      '#type' => 'fieldset',
+      '#collapsed' => FALSE,
+      '#collapsible' => TRUE,
+      '#title' => t('License'),
+    );
+
+    $element['license_fieldset']['allow_modifications'] = array(
+      '#type' => 'select',
+      '#title' => t('Allow modifications of your work?'),
+      '#options' => $modification_options,
+      '#default_value' => $derivatives,
+      '#ajax' => array(
+        'wrapper' => $license_output_id,
+        'callback' => 'xml_form_elements_creative_commons_ajax',
+      ),
+    );
+
+    $element['license_fieldset']['allow_commercial'] = array(
+      '#type' => 'select',
+      '#title' => t('Allow commercial uses of your work?'),
+      '#options' => $commercial_options,
+      '#default_value' => $commercial,
+      '#ajax' => array(
+        'wrapper' => $license_output_id,
+        'callback' => 'xml_form_elements_creative_commons_ajax',
+      ),
+    );
+
+    $element['license_fieldset']['license_jurisdiction'] = array(
+      '#type' => 'select',
+      '#title' => t('License Jurisdiction'),
+      '#options' => $countries,
+      '#default_value' => $jurisdiction,
+      '#ajax' => array(
+        'wrapper' => $license_output_id,
+        'callback' => 'xml_form_elements_creative_commons_ajax',
+      ),
+    );
+    // Value gets populated if default value is populated.
+    if (current_path() == 'system/ajax' || !$element['#value'] ||
+      (isset($element['#default_value']) && $element['#value'] == $element['#default_value'])) {
+      $element['#tree'] = TRUE;
     }
     else {
-      $jurisdiction = 'international';
+      // I win form builder.
+      $element['#tree'] = FALSE;
     }
-  }
-  else {
-    $derivatives = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_modifications']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_modifications'] : variable_get('xml_form_builder_cc_default_allow_derivatives', 'y');
-    $commercial = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_commercial']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_commercial'] : variable_get('xml_form_builder_cc_default_allow_commercial', 'y');
-    $jurisdiction = isset($form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction']) ? $form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction'] : variable_get('xml_form_builder_cc_default_jurisdiction', 'international');
-  }
 
-  // Fix for static variables
-  $modification_options = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$modification_options);
-  $commercial_options = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$commercial_options);
-  $countries = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$countries);
+    $response = CreativeCommons::xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction);
+    if ($response) {
+      $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = (string) $response->{'license-uri'};
+      $element['license_fieldset']['license_output'] = array(
+        '#type' => 'item',
+        '#id' => $license_output_id,
+        '#markup' => '<strong>' . t('Selected license:') . '</strong><div>' . $response->html->asXml() . '</div>',
+      );
+    }
+    else {
+      $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = CreativeCommons::xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction);
+      $element['license_fieldset']['license_output'] = array();
+    }
 
-  // Form elements.
-  $element['license_fieldset'] = array(
-    '#type' => 'fieldset',
-    '#collapsed' => FALSE,
-    '#collapsible' => TRUE,
-    '#title' => t('License'),
-  );
-
-  $element['license_fieldset']['allow_modifications'] = array(
-    '#type' => 'select',
-    '#title' => t('Allow modifications of your work?'),
-    '#options' => $modification_options,
-    '#default_value' => $derivatives,
-    '#ajax' => array(
-      'wrapper' => $license_output_id,
-      'callback' => 'xml_form_elements_creative_commons_ajax',
-    ),
-  );
-
-  $element['license_fieldset']['allow_commercial'] = array(
-    '#type' => 'select',
-    '#title' => t('Allow commercial uses of your work?'),
-    '#options' => $commercial_options,
-    '#default_value' => $commercial,
-    '#ajax' => array(
-      'wrapper' => $license_output_id,
-      'callback' => 'xml_form_elements_creative_commons_ajax',
-    ),
-  );
-
-  $element['license_fieldset']['license_jurisdiction'] = array(
-    '#type' => 'select',
-    '#title' => t('License Jurisdiction'),
-    '#options' => $countries,
-    '#default_value' => $jurisdiction,
-    '#ajax' => array(
-      'wrapper' => $license_output_id,
-      'callback' => 'xml_form_elements_creative_commons_ajax',
-    ),
-  );
-  // Value gets populated if default value is populated.
-  if (current_path() == 'system/ajax' || !$element['#value'] ||
-    (isset($element['#default_value']) && $element['#value'] == $element['#default_value'])) {
-    $element['#tree'] = TRUE;
-  }
-  else {
-    // I win form builder.
-    $element['#tree'] = FALSE;
+    return $element;
   }
 
-  $response = CreativeCommons::xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction);
-  if ($response) {
-    $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = (string) $response->{'license-uri'};
-    $element['license_fieldset']['license_output'] = array(
-      '#type' => 'item',
-      '#id' => $license_output_id,
-      '#markup' => '<strong>' . t('Selected license:') . '</strong><div>' . $response->html->asXml() . '</div>',
-    );
-  }
-  else {
-    $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = CreativeCommons::xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction);
-    $element['license_fieldset']['license_output'] = array();
+  /**
+   * Ask the creative commons REST API for a license.
+   *
+   * Left as a function for use by community modules.
+   *
+   * @param string $commercial
+   *   'y' to allow 'n' to disallow.
+   * @param string $derivatives
+   *   'y' to allow 'n' to disallow.
+   * @param string $jurisdiction
+   *   Legal jurisdiction code.
+   *
+   * @return mixed
+   *   SimpleXMLElement the return from the REST API.
+   *   FALSE if failed request.
+   */
+  public static function xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction) {
+    $response = drupal_http_request(url(
+      'http://api.creativecommons.org/rest/1.5/license/standard/get',
+      array(
+        'query' => array(
+          'commercial' => $commercial,
+          'derivatives' => $derivatives,
+          'jurisdiction' => $jurisdiction,
+        ),
+      )
+    ));
+    if ($response->code != 200) {
+      return FALSE;
+    }
+    return simplexml_load_string($response->data, 'SimpleXMLElement');
   }
 
-  return $element;
+  /**
+   * Gets the value for the element.
+   *
+   * @param string $commercial
+   *   'y' to allow 'n' to disallow.
+   * @param string $derivatives
+   *   'y' to allow 'n' to disallow.
+   * @param string $jurisdiction
+   *   Legal jurisdiction code.
+   *
+   * @return string
+   *   The value of the element.
+   */
+  public static function xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction) {
+    $arguments = '';
+    if ($commercial == 'n') {
+      $arguments = "$arguments-nc";
+    }
+    if ($derivatives == 'n') {
+      $arguments = "$arguments-nd";
+    }
+    elseif ($derivatives == 'sa') {
+      $arguments = "$arguments-sa";
+    }
+    return "http://creativecommons.org/licenses/by$arguments/2.5/$jurisdiction/";
+  }
+
+  /**
+   * Static class variables can't be defined with the t(), 
+   * so this allows us to add it after the fact using array_walk.
+   *
+   * @param string $value
+   *    array value to apply t() to
+   *
+   * @return string
+   *    the t() modified string
+   */
+  public static function xml_form_builder_fix_variables($value) {
+    return t($value);
+  }
 }
 
 /**
  * Ajax callback to render the CC license.
  */
-public static function xml_form_elements_creative_commons_ajax(&$form, &$form_state) {
+function xml_form_elements_creative_commons_ajax(&$form, &$form_state) {
   $parents = $form_state['triggering_element']['#parents'];
   array_pop($parents);
   $creative_commons_element = drupal_array_get_nested_value($form, $parents);
 
   return $creative_commons_element['license_output'];
-}
-
-/**
- * Ask the creative commons REST API for a license.
- *
- * Left as a function for use by community modules.
- *
- * @param string $commercial
- *   'y' to allow 'n' to disallow.
- * @param string $derivatives
- *   'y' to allow 'n' to disallow.
- * @param string $jurisdiction
- *   Legal jurisdiction code.
- *
- * @return mixed
- *   SimpleXMLElement the return from the REST API.
- *   FALSE if failed request.
- */
-public static function xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction) {
-  $response = drupal_http_request(url(
-    'http://api.creativecommons.org/rest/1.5/license/standard/get',
-    array(
-      'query' => array(
-        'commercial' => $commercial,
-        'derivatives' => $derivatives,
-        'jurisdiction' => $jurisdiction,
-      ),
-    )
-  ));
-  if ($response->code != 200) {
-    return FALSE;
-  }
-  return simplexml_load_string($response->data, 'SimpleXMLElement');
-}
-
-/**
- * Gets the value for the element.
- *
- * @param string $commercial
- *   'y' to allow 'n' to disallow.
- * @param string $derivatives
- *   'y' to allow 'n' to disallow.
- * @param string $jurisdiction
- *   Legal jurisdiction code.
- *
- * @return string
- *   The value of the element.
- */
-public static function xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction) {
-  $arguments = '';
-  if ($commercial == 'n') {
-    $arguments = "$arguments-nc";
-  }
-  if ($derivatives == 'n') {
-    $arguments = "$arguments-nd";
-  }
-  elseif ($derivatives == 'sa') {
-    $arguments = "$arguments-sa";
-  }
-  return "http://creativecommons.org/licenses/by$arguments/2.5/$jurisdiction/";
-}
-
-/**
- * Static class variables can't be defined with the t(), 
- * so this allows us to add it after the fact using array_walk.
- *
- * @param string $value
- *    array value to apply t() to
- *
- * @return string
- *    the t() modified string
- */
-public static function xml_form_builder_fix_variables($value) {
-  return t($value);
-}
 }

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -142,7 +142,7 @@ public static function xml_form_elements_creative_commons($element, &$form_state
   // Fix for static variables
   $modification_options = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$modification_options);
   $commercial_options = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$commercial_options);
-  $jurisdiction = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$jurisdiction);
+  $countries = array_map(array('CreativeCommons', 'xml_form_builder_fix_variables'), CreativeCommons::$countries);
 
   // Form elements.
   $element['license_fieldset'] = array(

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -5,23 +5,16 @@
  * Code for creative commons form elements.
  */
 
-/**
- * Creates a creative_commons form element.
- *
- * @param array $form_state
- *   The form state.
- *
- * @return array
- *   The element definition.
- */
-function xml_form_elements_creative_commons($element, &$form_state) {
-  $modification_options = array(
+
+class CreativeCommons {
+  
+  public static $modification_options = array(
     'y' => t('Yes'),
     'n' => t('No'),
     'sa' => t('Yes, as long as others share alike'),
   );
 
-  $countries = array(
+  public static $countries = array(
     'international' => t('International'),
     'ar' => t('Argentina'),
     'au' => t('Australia'),
@@ -83,17 +76,28 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     'vn' => t('Vietnam'),
   );
 
-  $commercial_options = array(
+  public static $commercial_options = array(
     'y' => t('Yes'),
     'n' => t('No'),
   );
+/**
+ * Creates a creative_commons form element.
+ *
+ * @param array $form_state
+ *   The form state.
+ *
+ * @return array
+ *   The element definition.
+ */
+public static function xml_form_elements_creative_commons($element, &$form_state) {
 
   // Get an ID for ajax.
   if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'])) {
     $license_output_id = $form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'];
   }
   else {
-    $license_output_id = drupal_html_id('license_output');
+    # $license_output_id = drupal_html_id('license_output');
+    $license_output_id = 'license_output';
     $form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'] = $license_output_id;
   }
 
@@ -103,8 +107,8 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     $default_value_array = array_reverse(explode('/', $element['#default_value']));
     $properties = explode('-', $default_value_array[3]);
 
-    $commercial = 'y';
-    $derivatives = 'y';
+    $commercial = variable_get('xml_form_builder_cc_default_allow_commercial', 'y');
+    $derivatives = variable_get('xml_form_builder_cc_default_allow_derivatives', 'y');
 
     foreach ($properties as $property) {
       switch ($property) {
@@ -125,12 +129,12 @@ function xml_form_elements_creative_commons($element, &$form_state) {
       }
     }
 
-    $jurisdiction = empty($default_value_array[1]) ? 'international' : $default_value_array[1];
+    $jurisdiction = empty($default_value_array[1]) ? variable_get('xml_form_builder_cc_default_jurisdiction', 'international') : $default_value_array[1];
   }
   else {
-    $derivatives = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_modifications']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_modifications'] : 'y';
-    $commercial = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_commercial']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_commercial'] : 'y';
-    $jurisdiction = isset($form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction']) ? $form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction'] : 'ca';
+    $derivatives = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_modifications']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_modifications'] : variable_get('xml_form_builder_cc_default_allow_derivatives', 'y');
+    $commercial = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_commercial']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_commercial'] : variable_get('xml_form_builder_cc_default_allow_commercial', 'y');
+    $jurisdiction = isset($form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction']) ? $form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction'] : variable_get('xml_form_builder_cc_default_jurisdiction', 'international');
   }
 
   // Form elements.
@@ -144,7 +148,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   $element['license_fieldset']['allow_modifications'] = array(
     '#type' => 'select',
     '#title' => t('Allow modifications of your work?'),
-    '#options' => $modification_options,
+    '#options' => CreativeCommons::$modification_options,
     '#default_value' => $derivatives,
     '#ajax' => array(
       'wrapper' => $license_output_id,
@@ -155,7 +159,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   $element['license_fieldset']['allow_commercial'] = array(
     '#type' => 'select',
     '#title' => t('Allow commercial uses of your work?'),
-    '#options' => $commercial_options,
+    '#options' => CreativeCommons::$commercial_options,
     '#default_value' => $commercial,
     '#ajax' => array(
       'wrapper' => $license_output_id,
@@ -166,7 +170,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   $element['license_fieldset']['license_jurisdiction'] = array(
     '#type' => 'select',
     '#title' => t('License Jurisdiction'),
-    '#options' => $countries,
+    '#options' => CreativeCommons::$countries,
     '#default_value' => $jurisdiction,
     '#ajax' => array(
       'wrapper' => $license_output_id,
@@ -203,7 +207,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
 /**
  * Ajax callback to render the CC license.
  */
-function xml_form_elements_creative_commons_ajax(&$form, &$form_state) {
+public static function xml_form_elements_creative_commons_ajax(&$form, &$form_state) {
   $parents = $form_state['triggering_element']['#parents'];
   array_pop($parents);
   $creative_commons_element = drupal_array_get_nested_value($form, $parents);
@@ -227,7 +231,7 @@ function xml_form_elements_creative_commons_ajax(&$form, &$form_state) {
  *   SimpleXMLElement the return from the REST API.
  *   FALSE if failed request.
  */
-function xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction) {
+public static function xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction) {
   $response = drupal_http_request(url(
     'http://api.creativecommons.org/rest/1.5/license/standard/get',
     array(
@@ -257,7 +261,7 @@ function xml_form_elements_get_creative_commons($commercial, $derivatives, $juri
  * @return string
  *   The value of the element.
  */
-function xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction) {
+public static function xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction) {
   $arguments = '';
   if ($commercial == 'n') {
     $arguments = "$arguments-nc";
@@ -269,4 +273,5 @@ function xml_form_elements_creative_commons_value($commercial, $derivatives, $ju
     $arguments = "$arguments-sa";
   }
   return "http://creativecommons.org/licenses/by$arguments/2.5/$jurisdiction/";
+}
 }

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -203,7 +203,6 @@ class CreativeCommons {
       // I win form builder.
       $element['#tree'] = FALSE;
     }
-
     $response = CreativeCommons::xmlFormElementsGetCreativeCommons($commercial, $derivatives, $jurisdiction);
     if ($response) {
       $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = (string) $response->{'license-uri'};
@@ -217,7 +216,6 @@ class CreativeCommons {
       $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = CreativeCommons::xmlFormElementsCreativeCommonsValue($commercial, $derivatives, $jurisdiction);
       $element['license_fieldset']['license_output'] = array();
     }
-
     return $element;
   }
 
@@ -291,7 +289,7 @@ class CreativeCommons {
    *   the t() modified string
    */
   public static function xmlFormBuilderFixVariables($value) {
-    return t('%t', array('%t' => $value));
+    return t('@t', array('@t' => $value));
   }
 }
 

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -482,7 +482,7 @@ function xml_form_elements_defaultable_markup($children, &$elements) {
  */
 function xml_form_elements_creative_commons_process($element, &$form_state, $complete_form) {
   form_load_include($form_state, 'inc', 'xml_form_elements', 'includes/creative_commons');
-  return CreativeCommons::xml_form_elements_creative_commons($element, $form_state);
+  return CreativeCommons::xmlFormElementsCreativeCommons($element, $form_state);
 }
 
 /**
@@ -510,7 +510,13 @@ function xml_form_elements_creative_commons_value_callback(&$element, $input, &$
     }
     else {
       extract($input['license_fieldset']);
-      return CreativeCommons::xml_form_elements_creative_commons_value($allow_commercial, $allow_modifications, $license_jurisdiction);
+      $response = CreativeCommons::xmlFormElementsGetCreativeCommons($allow_commercial, $allow_modifications, $license_jurisdiction);
+      if ($response) {
+        return (string) $response->{'license-uri'};
+      }
+      else {
+        return CreativeCommons::xmlFormElementsCreativeCommonsValue($allow_commercial, $allow_modifications, $license_jurisdiction);
+      }
     }
   }
 }

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -482,7 +482,7 @@ function xml_form_elements_defaultable_markup($children, &$elements) {
  */
 function xml_form_elements_creative_commons_process($element, &$form_state, $complete_form) {
   form_load_include($form_state, 'inc', 'xml_form_elements', 'includes/creative_commons');
-  return xml_form_elements_creative_commons($element, $form_state);
+  return CreativeCommons::xml_form_elements_creative_commons($element, $form_state);
 }
 
 /**
@@ -510,7 +510,7 @@ function xml_form_elements_creative_commons_value_callback(&$element, $input, &$
     }
     else {
       extract($input['license_fieldset']);
-      return xml_form_elements_creative_commons_value($allow_commercial, $allow_modifications, $license_jurisdiction);
+      return CreativeCommons::xml_form_elements_creative_commons_value($allow_commercial, $allow_modifications, $license_jurisdiction);
     }
   }
 }


### PR DESCRIPTION
Two things here. 

One is adding default Creative Commons settings to the admin form, so that new objects start with your default. Otherwise you have to change them every time. Just saves a little effort.

Second is that the drupal_html_id('license_output') doesn't work reliably with AJAX. There is quite a bit of discussion about this on various forums. The form loads fine, make on change and AJAX works. But the second and subsequent did not seem to replace the license display.

I don't see why you would ever have multiple CC choosers on a single object, but if nothing else you may want to look at modify your code to just fix this one problem.

cheers
