### PR TITLE
Handle double quotes in Tag elements

### DIFF
--- a/elements/includes/Tag.inc
+++ b/elements/includes/Tag.inc
@@ -58,6 +58,7 @@ class Tag {
     $tags = &get_form_element_parent($element, $complete_form);
     $element['#id'] = $element['#hash'];
     $element['#title'] = isset($tags['#title']) ? $tags['#title'] : FALSE;
+    $element['#value'] = isset($element['#value']) ? check_plain($element['#value']) : FALSE;
     return $element;
   }
 }

--- a/elements/templates/Tags.tpl.php
+++ b/elements/templates/Tags.tpl.php
@@ -21,7 +21,7 @@
   <span class="tag-list">
     <?php foreach ($tags as $tag): ?>
       <span title="<?php print "{$tag['#value']}" ?>">
-        <span class="edit-tag" onclick="jQuery('#<?php print $edit[$tag['#hash']]['#id'] ?>').trigger('mousedown'); return false;"><?php print "{$tag['#value']}" ?></span>
+        <span class="edit-tag" onclick="jQuery('#<?php print $edit[$tag['#hash']]['#id'] ?>').trigger('mousedown'); return false;"><?php print decode_entities("{$tag['#value']}") ?></span>
         <span class="remove-tag" onclick="jQuery('#<?php print $remove[$tag['#hash']]['#id'] ?>').trigger('mousedown'); return false;"></span>
       </span>
     <?php endforeach ?>


### PR DESCRIPTION
Runs tag values through check_plain to keep them from breaking with double-quotes, un-escape for display.

Addresses [ISLANDORA-872](https://jira.duraspace.org/browse/ISLANDORA-872)
