### PR TITLE
Fixes JIRA ISLANDORA-1342

### DIFF
--- a/builder/js/ElementForm.js
+++ b/builder/js/ElementForm.js
@@ -51,8 +51,9 @@ Ext.formbuilder.createElementForm = function () {
       name: 'key',
       fieldLabel: Drupal.t('Identifier'),
       width: 640,
-      regex: /^[^!"#$%&'()*+,.\/\\:;<=>?@[\]^`{|}~]+$/,
-      regexText: "Invalid Identifier it must not contain (^!\"#$%&'()*+,.\/:;<=>?@[\]^`{|}~)",
+      allowBlank: false,
+      regex: /^[a-zA-Z0-9_\-\x7f-\xff][a-zA-Z0-9_\-\x7f-\xff]*$/,
+      regexText: "Invalid Identifier, it may only contain letters, numbers, hyphens or underscores",
       listeners: {
         render: function() {
           Ext.create('Ext.tip.ToolTip', {


### PR DESCRIPTION
Changed the regex pattern in Element form definition for EXTJS for
"key" field.
It's not fully compliant with PHP definition for a variable name nor
W3C definition for DOM element attribute "name", but it validates
against drupal form array structure, and submission - XML generation
works fine. 

I made the pattern intentionally "two part", even when start matching is the same as consecutive one, because it would be nice if we could in the future limit more the starting characters, disallowing , e.g. "-"

Would love to have this been more restrictive - standards compliant,
but this would break existing things (like tab elements that use "0" as
name…)
AllowBlank was set to false also.
