### PR TITLE
Drupal 7.39 breaks autocomplete functionality

### DIFF
--- a/elements/includes/Tag.inc
+++ b/elements/includes/Tag.inc
@@ -56,7 +56,9 @@ class Tag {
    */
   public static function Process(array $element, array &$form_state, array $complete_form = NULL) {
     $tags = &get_form_element_parent($element, $complete_form);
-    $element['#id'] = $element['#hash'];
+    // Remove numbers from the ID, since they can
+    // cause problems during the autocomplete process.
+    $element['#id'] = rtrim(preg_replace('/\d+/', '', $element['#id']), '-');
     $element['#title'] = isset($tags['#title']) ? $tags['#title'] : FALSE;
     $element['#value'] = isset($element['#value']) ? check_plain($element['#value']) : FALSE;
     return $element;

--- a/elements/includes/Tag.inc
+++ b/elements/includes/Tag.inc
@@ -56,9 +56,7 @@ class Tag {
    */
   public static function Process(array $element, array &$form_state, array $complete_form = NULL) {
     $tags = &get_form_element_parent($element, $complete_form);
-    // Remove numbers from the ID, since they can
-    // cause problems during the autocomplete process.
-    $element['#id'] = rtrim(preg_replace('/\d+/', '', $element['#id']), '-');
+    $element['#id'] = $element['#hash'];
     $element['#title'] = isset($tags['#title']) ? $tags['#title'] : FALSE;
     $element['#value'] = isset($element['#value']) ? check_plain($element['#value']) : FALSE;
     return $element;

--- a/elements/includes/Tags.inc
+++ b/elements/includes/Tags.inc
@@ -225,7 +225,6 @@ function template_preprocess_tags(&$vars) {
   $textfield = array(
     'element' => array_shift($vars['tags']),
   );
-  $textfield['element']['#id'] = $tags['#id'];
   $textfield['element']['#size'] = $tags['#size'];
   $textfield['element']['#autocomplete_path'] = isset($textfield['element']['#autocomplete_path']) ? $textfield['element']['#autocomplete_path'] : FALSE;
   // Theme the text field to take advantage of autocomplete.

--- a/elements/includes/Tags.inc
+++ b/elements/includes/Tags.inc
@@ -55,9 +55,7 @@ class Tags {
    */
   public static function Process(array $element, array &$form_state, array $complete_form = NULL) {
     self::addRequiredResources($form_state);
-    // Remove numbers from the ID, since they can
-    // cause problems during the autocomplete process.
-    $element['#id'] = rtrim(preg_replace('/\d+/', '', $element['#id']), '-');
+    $element['#id'] = $element['#hash'];
     $element['#size'] = isset($element['#size']) ? $element['#size'] : 60;
     $element['#tree'] = TRUE;
     $element['#after_build'] = array('xml_form_elements_after_build_tags');

--- a/elements/includes/Tags.inc
+++ b/elements/includes/Tags.inc
@@ -55,7 +55,9 @@ class Tags {
    */
   public static function Process(array $element, array &$form_state, array $complete_form = NULL) {
     self::addRequiredResources($form_state);
-    $element['#id'] = $element['#hash'];
+    // Remove numbers from the ID, since they can
+    // cause problems during the autocomplete process.
+    $element['#id'] = rtrim(preg_replace('/\d+/', '', $element['#id']), '-');
     $element['#size'] = isset($element['#size']) ? $element['#size'] : 60;
     $element['#tree'] = TRUE;
     $element['#after_build'] = array('xml_form_elements_after_build_tags');

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -370,6 +370,8 @@ function xml_form_elements_form_element_tags_ajax_add(FormElement $element, arra
   $input->parent->adopt($tag);
   $tag = $tag->toArray();
   $tag['#default_value'] = $default_value;
+  //Since cloned tags are not textfields just unset #autocomplete_path key.
+  unset($tag['#autocomplete_path']);
   // Update drupal form.
   $form[] = $tag;
 }

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -48,8 +48,7 @@ function xml_form_elements_element_info() {
     ),
     'tag' => array(
       '#input' => TRUE,
-      '#autocomplete_path' => FALSE,
-      '#process' => array('xml_form_elements_tag_process', 'form_process_autocomplete'),
+      '#process' => array('xml_form_elements_tag_process'),
       '#theme' => 'tag',
     ),
     'datepicker' => array(
@@ -107,6 +106,19 @@ function xml_form_elements_element_info() {
       ),
     ),
   );
+}
+
+/**
+ * Implements hook_element_info_alter().
+ */
+function xml_form_elements_element_info_alter(&$type) {
+  // As of Drupal 7.39, a new function is required to "sanitize" the
+  // autocomplete process and avoid cross-site scripting (SA-CORE-2015-003).
+  // For backward-compatibility, ensure this function exists before applying it.
+  if (function_exists('form_process_autocomplete')) {
+    $type['tag']['#autocomplete_path'] = FALSE;
+    $type['tag']['#process'][] = 'form_process_autocomplete';
+  }
 }
 
 /**

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -48,7 +48,8 @@ function xml_form_elements_element_info() {
     ),
     'tag' => array(
       '#input' => TRUE,
-      '#process' => array('xml_form_elements_tag_process'),
+      '#autocomplete_path' => FALSE,
+      '#process' => array('xml_form_elements_tag_process', 'form_process_autocomplete'),
       '#theme' => 'tag',
     ),
     'datepicker' => array(
@@ -81,7 +82,7 @@ function xml_form_elements_element_info() {
       '#process' => array('xml_form_elements_creative_commons_process'),
       '#value_callback' => 'xml_form_elements_creative_commons_value_callback',
     ),
-    // Designed for the form builder UI please do not use programaticaly.
+    // Designed for the form builder UI please do not use programmatically.
     'indent' => array(
       '#input' => FALSE,
       '#tree' => FALSE,
@@ -93,7 +94,7 @@ function xml_form_elements_element_info() {
         'css' => array("$module_path/css/indent.css"),
       ),
     ),
-    // Designed for the form builder UI please do not use programaticaly.
+    // Designed for the form builder UI please do not use programmatically.
     'inline' => array(
       '#input' => FALSE,
       '#tree' => FALSE,

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -370,7 +370,7 @@ function xml_form_elements_form_element_tags_ajax_add(FormElement $element, arra
   $input->parent->adopt($tag);
   $tag = $tag->toArray();
   $tag['#default_value'] = $default_value;
-  //Since cloned tags are not textfields just unset #autocomplete_path key.
+  // Since cloned tags are not textfields just unset #autocomplete_path key.
   unset($tag['#autocomplete_path']);
   // Update drupal form.
   $form[] = $tag;


### PR DESCRIPTION
<a href="http://drupal.org/drupal-7.39-release-notes">Drupal 7.39</a> came out on August 19, 2015 -- a security release. One of the vulnerabilities it was patching was <em>autocomplete</em>, which was open to cross-site scripting (<a href="http://drupal.org/SA-CORE-2015-003">SA-CORE-2015-003</a>). A new function was introduced (<a href="https://github.com/drupal/drupal/commit/be00a1ced4104d84df2f34b149b35fb0adf91093#diff-76b8e4a4630d8b8b09a8579c35fd31e9R3965">form_process_autocomplete</a>) to "sufficiently sanitize" requested URLs. Autocomplete broke for many modules after upgrading to Drupal 7.39 -- including islandora_xml_forms. This is because the function form_process_autocomplete() is now required as part of an element's "#process" array.

For islandora_xml_forms, this problem only appears to impact autocomplete fields where multiple values can be added. Single-item autocomplete fields seem unaffected by the upgrade.

Autocomplete (under Drupal 7.39) also seems to have a problem with field IDs with numbers in them. The module islandora_xml_forms has been overriding the element ID (which is usually based on the field name: <em>example:</em> <tt>formSections[subjects][topic]</tt> becomes <em>edit-formsections-subjects-topic</em>) and replacing it with a hash instead (<em>00000000682de34e000000015b767354</em>). As of 7.39, numbers in an ID seem to break the autocomplete functionality, which is why I reinstated the Drupal-built IDs. Multi-item fields can sometimes have zeroes at the end of their IDs, which is why numbers are being stripped out.
