### PR TITLE
ISLANDORA-1087: fixes WSOD

### DIFF
--- a/api/NodeRegistry.inc
+++ b/api/NodeRegistry.inc
@@ -26,6 +26,9 @@ class NodeRegistry implements Serializable {
    * object, NodeRegistry::restored() must be called to convert the XPaths back
    * to DOMNodes.
    *
+   * Registered DOMNodes should not be orphan. This leads to wrong XPaths that
+   * can't be converted back to DOMNodes.
+   *
    * @var array
    */
   protected $registered;
@@ -124,6 +127,22 @@ class NodeRegistry implements Serializable {
       throw new Exception("DOMNodes cannot be registered until this object has been restored. Make sure 'NodeRegistry::restore()' has been called after this object has been unserialized.");
     }
     $this->registered[$hash] = $node;
+  }
+
+  /**
+   * Unregisters a relationship between a FormElement and DOMNode.
+   *
+   * @param string $hash
+   *   The #hash property of the FormElement to remove from the registry.
+   *
+   * @throws Exception
+   *   If NodeRegistry::restoreRequired is flagged as true and this is called.
+   */
+  public function unregister($hash) {
+    if ($this->restoredRequired) {
+      throw new Exception("DOMNodes cannot be registered until this object has been restored. Make sure 'NodeRegistry::restore()' has been called after this object has been unserialized.");
+    }
+    unset($this->registered[$hash]);
   }
 
   /**

--- a/api/XMLFormProcessor.inc
+++ b/api/XMLFormProcessor.inc
@@ -213,7 +213,7 @@ class XMLFormProcessor {
     // nodeRegistry.
     // This is needed because the serialization and unserialization
     // process of NodeRegistry with orphan Domnodes results in invalid
-    // XPath's that silently fail when unserializing the supper
+    // XPath's that silently fail when unserializing the super
     // structure a.k.a $form_state.
     $registered = $this->nodeRegistry->getRegistered();
     $elements = $element->flatten();

--- a/api/XMLFormProcessor.inc
+++ b/api/XMLFormProcessor.inc
@@ -131,12 +131,15 @@ class XMLFormProcessor {
     // take place before updates; newly created elements can be registered as we
     // can update newly created elements. Delete must come last, as we want the
     // update actions to run on elements that may then later be removed.
+    // At last we clean up our nodeRegistry. This is necessary because after
+    // deletion we can end with orphan domnodes and attributes attached to this.
     $elements = $element->flatten();
     $filtered_elements = $this->filterElements($elements);
     $this->createNodes($this->getActions($filtered_elements, 'create'));
     $this->modifyNodes($this->getActions($filtered_elements, 'update'));
     $this->modifyNodes($this->getActions($filtered_elements, 'delete'));
     $this->modifyNodes($this->getRemovedFormElementsDeleteActions($element));
+    $this->cleanupNodeRegistry($element);
     return $this->document;
   }
 
@@ -194,6 +197,44 @@ class XMLFormProcessor {
   protected function modifyNodes(array $actions) {
     foreach ($actions as $action) {
       $action->execute($this->document);
+    }
+  }
+
+  /**
+   * Cleanups orphan DOMNodes from the registry.
+   *
+   * @param FormElement $element
+   *   The element to check against.
+   */
+  protected function cleanupNodeRegistry(FormElement $element) {
+    // Checks if the form elements associated with a DOMNodes where
+    // removed. If any found, verifies if the associated DOMNodes are
+    // attributes of an orphan node or orphan ones, removing those from
+    // nodeRegistry.
+    // This is needed because the serialization and unserialization
+    // process of NodeRegistry with orphan Domnodes results in invalid
+    // XPath's that silently fail when unserializing the supper
+    // structure a.k.a $form_state.
+    $registered = $this->nodeRegistry->getRegistered();
+    $elements = $element->flatten();
+    $filtered_elements = $this->filterElements($elements);
+    foreach ($registered as $hash => $node) {
+      if (isset($filtered_elements[$hash]) === FALSE) {
+        if ($node->nodeType === XML_ATTRIBUTE_NODE) {
+          if (!isset($node->ownerElement->parentNode)) {
+            $this->nodeRegistry->unregister($hash);
+          }
+        }
+        else {
+          $currentelement = $this->elementRegistry->get($hash);
+          $delete = isset($currentelement->actions->delete) ? $currentelement->actions->delete : NULL;
+          if (isset($delete)) {
+            if (!isset($node->parentNode)) {
+              $this->nodeRegistry->unregister($hash);
+            }
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
https://jira.duraspace.org/browse/ISLANDORA-1087

Fixes orphan DOMNodes associated to deleted Form elements when
processing the XML document on submit in Multistep workflows. 

Since all  objects used by XMLForms are stored inside $form_state and serialised 
by drupal to keep multistep form states, when the XML document is processed,
and after delete actions are run, we end with DOMNodes stored in the internal registry
that do not have parents, and also DOMAttrib associated to them. When
serialisation of this particular object happens every DOMNode is
converted to an XPath. On unserialise, those XPaths are not valid
agains the XML document and results in an silent exception when the
unserialization process is nested, destroying $form_state and by this
making form steps impossible.
