### PR TITLE
ISLANDORA-1380: Change scroll implementation

### DIFF
--- a/builder/js/TreePanel.js
+++ b/builder/js/TreePanel.js
@@ -20,6 +20,7 @@ Ext.formbuilder.createTreePanel = function() {
       }
     },
     width: 230,
+    height: 820,
     margin: '1 0 1 1',
     rootVisible: false,
     split: true,

--- a/builder/js/TreePanel.js
+++ b/builder/js/TreePanel.js
@@ -13,9 +13,14 @@ Ext.formbuilder.createTreePanel = function() {
     title: Drupal.t('Elements'),
     store: this.elementStore,
     region: 'west',
+    scroll: false,
+    viewConfig: {
+      style: {
+        overflow: 'auto'
+      }
+    },
     width: 230,
     margin: '1 0 1 1',
-    autoScroll: true,
     rootVisible: false,
     split: true,
     tbar: {


### PR DESCRIPTION
https://jira.duraspace.org/browse/ISLANDORA-1380

Islandora Vagrant Machine uses up to date versions for every drupal
Module. Jquery_update 3 Alpha-2 is one of those + Chrome interpretation
of certain not standard JS makes scrollbars on Form Editor (treepanel)
not being loaded. This triggers a false calc. on panel height/offset
making the toolbar for manipulating form elements "disappear". Since we
can't assure a specific JS interpretation/future compatibility for
every interacting module with our old ExtJS( the main JS framework used
by form builder and with many bugs) we removed the JS scrollbars
replacing this with an css implementation.  Tested on offending
browsers and firefox.
