### PR TITLE
ISLANDORA-1090 Write datastream mimetype as application/xml.

### DIFF
--- a/builder/xml_form_builder.module
+++ b/builder/xml_form_builder.module
@@ -631,15 +631,15 @@ function xml_form_builder_update_metadata_datastream(AbstractObject $object, $da
     if ($datastream->label != "$datastream_id Record") {
       $datastream->label = "$datastream_id Record";
     }
-    if ($datastream->mimetype != 'text/xml') {
-      $datastream->mimetype = 'text/xml';
+    if ($datastream->mimetype != 'application/xml') {
+      $datastream->mimetype = 'application/xml';
     }
   }
   else {
     $datastream = $object->constructDatastream($datastream_id, 'M');
     $datastream->setContentFromString(trim($document->saveXML()));
     $datastream->label = "$datastream_id Record";
-    $datastream->mimetype = 'text/xml';
+    $datastream->mimetype = 'application/xml';
     $object->ingestDatastream($datastream);
     $created = TRUE;
   }

--- a/tests/islandora_solution_pack_test/islandora_test_cm.module
+++ b/tests/islandora_solution_pack_test/islandora_test_cm.module
@@ -17,7 +17,7 @@ function islandora_test_cm_islandora_required_objects(IslandoraTuque $connection
   // DS-COMPOSITE-MODEL Datastream.
   $datastream = $test_content_model->constructDatastream('DS-COMPOSITE-MODEL', 'X');
   $datastream->label = 'DS-COMPOSITE-MODEL';
-  $datastream->mimetype = 'text/xml';
+  $datastream->mimetype = 'application/xml';
   $datastream->setContentFromFile("$module_path/xml/islandora_test_cm_ds_composite_model.xml", FALSE);
   $test_content_model->ingestDatastream($datastream);
   return array(


### PR DESCRIPTION
Note: There are many other places in this module where 'text/xml' is used, either as the media-type in xml documents, or as the Content-Type in HTTP headers. I don't know the implications of touching those, but this pull request should address the mimetype that the module assigns to its Fedora datastreams, so that MODS (or whatever else you use XML Form Builder for) will be written as 'application/xml'.  

Hopefully this will let us close 1090 (modifying a datastream makes two versions) - though if you test this on an object with a text/xml MODS, then modifying MODS WILL create two versions as the content and mimetype are changed. 
