### PR TITLE
ISLANDORA-1547

### DIFF
--- a/builder/xml_form_builder.module
+++ b/builder/xml_form_builder.module
@@ -532,7 +532,7 @@ function xml_form_builder_islandora_edit_datastream_registry(AbstractObject $obj
   $associations = xml_form_builder_get_associations(array(), $object->models, array($datastream->id));
   if (count($associations) > 0) {
     return array(
-      array(
+      'xml_form_builder_edit_form_registry' => array(
         'name' => t('Islandora Content Model Forms'),
         'url' => "islandora/edit_form/{$object->id}/{$datastream->id}",
       ),


### PR DESCRIPTION
**Related Pull:** https://github.com/Islandora/islandora/pull/637

**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1547
# What does this Pull Request do?

Adds a drupal_alter to allow for modification to the datastream edit registry.
# How should this be tested?

Pull down the pull both the islandora (core) pull request and the islandora_xml_forms pull request.

Test 1: Confirming the addition of an custom index value does not impact form loading.
Edit an existing object's datastream the process should function the same as before the pull and load
the registry item built in xml_form_builder_islandora_edit_datastream_registry. 

Test 2: Testing the drupal_alter.
Have a module implement hook_islandora_edit_datastream_modify_registry_alter() and test making changes to the edit_registry.

  1) Adding an edition registry item - this should load the default switch logic so that multiple routes are rendered.

  2) Removing unset the $edit_registry - this should trigger switch case 0 and return the user to the manage datastream page with a drupal message "There are no edit methods specified for this datastream."

  3) Assuming the registry has just the values for xml_form_builder_edit_form_registry. Edit the url path for $edit_registry['xml_form_builder_edit_form_registry']['url'] and point it to another page.  This page should load when you click edit on a datastream.

  4) Try the above 1-3 type changes but limit using the object's content model or the datastream being modified.
# Background context:

A way of loading a custom edit form when modifying a datastream without having to use a goto in a form_alter. While keeping the user from having to select the registry route manually.  By making modifications to the edit registry it helps avoid any potential confusion from building one form and redirecting to another.

**Tagging:** @Islandora/7-x-1-x-committers, @ruebot, @DiegoPino 

---

Matthew Perry
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
