### PR TITLE
ISLANDORA-1559

### DIFF
--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -298,9 +298,28 @@ function xml_form_elements_form_element_tabs_ajax_alter(FormElement $element, ar
 function xml_form_elements_form_element_tabs_ajax_add(FormElement $element, array &$form, array &$form_state) {
   $tab = $element->findElement($form_state['triggering_element']['#ajax']['params']['child']);
   $new_tab = clone $tab;
-  $new_tab->eachDecendant(function($element) {
-    $element->default_value = NULL;
-  });
+  // Load an empty copy of the curreny xml form to be used for setting defaults
+  // field values of the cloned tab.
+  if ($form_state['build_info']['form_id'] == 'xml_form_builder_preview') {
+    $form_name = $form_state['build_info']['args']['0'];
+  }
+  else {
+    $form_name = $form_state['association']['form_name'];
+  }
+  $empty_form = drupal_get_form($form_name);
+  $tab_field = $form_state['triggering_element']['#parents']['0'];
+  $tab_index = $form_state['triggering_element']['#parents']['1'];
+  $original_tabs = isset($empty_form[$tab_field][$tab_index]) ? $empty_form[$tab_field][$tab_index] : NULL;
+
+  $set_default_value = function ($element, $original_tabs) {
+    $default = NULL;
+    // Attempt to set the default based on the configured default form value.
+    if (isset($original_tabs[$element->getIndex()]['#default_value'])) {
+      $default = $original_tabs[$element->getIndex()]['#default_value'];
+    }
+    $element->default_value = $default;
+  };
+  $new_tab->eachDecendant($set_default_value, $original_tabs);
   $element->adopt($new_tab);
   $form[] = $new_tab->toArray();
 }

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -298,28 +298,9 @@ function xml_form_elements_form_element_tabs_ajax_alter(FormElement $element, ar
 function xml_form_elements_form_element_tabs_ajax_add(FormElement $element, array &$form, array &$form_state) {
   $tab = $element->findElement($form_state['triggering_element']['#ajax']['params']['child']);
   $new_tab = clone $tab;
-  // Load an empty copy of the curreny xml form to be used for setting defaults
-  // field values of the cloned tab.
-  if ($form_state['build_info']['form_id'] == 'xml_form_builder_preview') {
-    $form_name = $form_state['build_info']['args']['0'];
-  }
-  else {
-    $form_name = $form_state['association']['form_name'];
-  }
-  $empty_form = drupal_get_form($form_name);
-  $tab_field = $form_state['triggering_element']['#parents']['0'];
-  $tab_index = $form_state['triggering_element']['#parents']['1'];
-  $original_tabs = isset($empty_form[$tab_field][$tab_index]) ? $empty_form[$tab_field][$tab_index] : NULL;
-
-  $set_default_value = function ($element, $original_tabs) {
-    $default = NULL;
-    // Attempt to set the default based on the configured default form value.
-    if (isset($original_tabs[$element->getIndex()]['#default_value'])) {
-      $default = $original_tabs[$element->getIndex()]['#default_value'];
-    }
-    $element->default_value = $default;
-  };
-  $new_tab->eachDecendant($set_default_value, $original_tabs);
+  $new_tab->eachDecendant(function($element) {
+    $element->default_value = $element->getOriginalDefaultValue();
+  });
   $element->adopt($new_tab);
   $form[] = $new_tab->toArray();
 }


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1559
# Other Related Pull - Objective Forms:

https://github.com/Islandora/objective_forms/pull/40
# What does this Pull Request do?

Makes new tabs that are created respect the original form default values.
# How should this be tested?

By using a form builder form that has a tabpanel which has a field that uses a default value.  This default value should now prepopulate into the newly cloned tab instead of forcing to NULL.

Test the form while ingesting, editing, and using the form in the Form Builder Preview (when editing the form).

Example 1: 
Default Form: Collection MODS Form 
Within this form the name (tabs) -> 0 (tabpanel) -> type (select) it has the default value set of personal. 

The first tab when you load the form uses the correct default but as soon as you add a new tab the newly cloned tab will default to corporate as this is the first option in the select box. 

With this change when you add the new tab it will load the default value of the initial "empty/new" form and set the select option to personal, while continuing to force fields without a default value to NULL so they remain empty.
# Background context:

Causes issues when using tabs that have set values and when new tabs are created without having the values set can result in missing xml values/attributes. 

**Tagging:** @DiegoPino, @ruebot, @nigelgbanks 

---

Matthew Perry
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
