### PR TITLE
ISLANDORA-1605: Better element Registry cleanup

### DIFF
--- a/api/NodeRegistry.inc
+++ b/api/NodeRegistry.inc
@@ -140,7 +140,7 @@ class NodeRegistry implements Serializable {
    */
   public function unregister($hash) {
     if ($this->restoredRequired) {
-      throw new Exception("DOMNodes cannot be registered until this object has been restored. Make sure 'NodeRegistry::restore()' has been called after this object has been unserialized.");
+      throw new Exception("DOMNodes cannot be unregistered until this object has been restored. Make sure 'NodeRegistry::restore()' has been called after this object has been unserialized.");
     }
     unset($this->registered[$hash]);
   }

--- a/api/XMLFormProcessor.inc
+++ b/api/XMLFormProcessor.inc
@@ -137,6 +137,8 @@ class XMLFormProcessor {
     $filtered_elements = $this->filterElements($elements);
     $this->createNodes($this->getActions($filtered_elements, 'create'));
     $this->modifyNodes($this->getActions($filtered_elements, 'update'));
+    // This does nothing right now.
+    // AppendIteratorDelete actions always return false to shouldExecute().
     $this->modifyNodes($this->getActions($filtered_elements, 'delete'));
     $this->modifyNodes($this->getRemovedFormElementsDeleteActions($element));
     $this->cleanupNodeRegistry($element);
@@ -209,16 +211,17 @@ class XMLFormProcessor {
   protected function cleanupNodeRegistry(FormElement $element) {
     // Checks if the form elements associated with a DOMNodes where
     // removed. If any found, verifies if the associated DOMNodes are
-    // attributes of an orphan node or orphan ones, removing those from
-    // nodeRegistry.
+    // attributes of an orphan node or descentants of one that had a delete
+    // action processed, removing those from nodeRegistry.
     // This is needed because the serialization and unserialization
-    // process of NodeRegistry with orphan Domnodes results in invalid
-    // XPath's that silently fail when unserializing the super
+    // process of NodeRegistry with orphan DOMNodes results in invalid
+    // XPaths that silently fail when unserializing the super
     // structure a.k.a $form_state.
     $registered = $this->nodeRegistry->getRegistered();
     $elements = $element->flatten();
     $filtered_elements = $this->filterElements($elements);
-    foreach ($registered as $hash => $node) {
+    $elements_tounregister = array();
+    foreach ($registered as $hash => &$node) {
       if (isset($filtered_elements[$hash]) === FALSE) {
         if ($node->nodeType === XML_ATTRIBUTE_NODE) {
           if (!isset($node->ownerElement->parentNode)) {
@@ -229,8 +232,10 @@ class XMLFormProcessor {
           $currentelement = $this->elementRegistry->get($hash);
           $delete = isset($currentelement->actions->delete) ? $currentelement->actions->delete : NULL;
           if (isset($delete)) {
-            if (!isset($node->parentNode)) {
-              $this->nodeRegistry->unregister($hash);
+            $elements_tounregister = array_keys($currentelement->flatten());
+            foreach ($elements_tounregister as $descendant_hash) {
+              $this->nodeRegistry->unregister($descendant_hash);
+              unset($registered[$descendant_hash]);
             }
           }
         }

--- a/api/XMLFormProcessor.inc
+++ b/api/XMLFormProcessor.inc
@@ -220,7 +220,6 @@ class XMLFormProcessor {
     $registered = $this->nodeRegistry->getRegistered();
     $elements = $element->flatten();
     $filtered_elements = $this->filterElements($elements);
-    $elements_tounregister = array();
     foreach ($registered as $hash => &$node) {
       if (isset($filtered_elements[$hash]) === FALSE) {
         if ($node->nodeType === XML_ATTRIBUTE_NODE) {

--- a/api/XMLFormProcessor.inc
+++ b/api/XMLFormProcessor.inc
@@ -211,10 +211,10 @@ class XMLFormProcessor {
   protected function cleanupNodeRegistry(FormElement $element) {
     // Checks if the form elements associated with a DOMNodes where
     // removed. If any found, verifies if the associated DOMNodes are
-    // attributes of an orphan node or descentants of one that had a delete
+    // attributes of an orphan node or descendants of one that had a delete
     // action processed, removing those from nodeRegistry.
     // This is needed because the serialization and unserialization
-    // process of NodeRegistry with orphan DOMNodes results in invalid
+    // process of nodeRegistry with orphan DOMNodes results in invalid
     // XPaths that silently fail when unserializing the super
     // structure a.k.a $form_state.
     $registered = $this->nodeRegistry->getRegistered();

--- a/api/XMLFormProcessor.inc
+++ b/api/XMLFormProcessor.inc
@@ -138,7 +138,7 @@ class XMLFormProcessor {
     $this->createNodes($this->getActions($filtered_elements, 'create'));
     $this->modifyNodes($this->getActions($filtered_elements, 'update'));
     // This does nothing right now.
-    // AppendIteratorDelete actions always return false to shouldExecute().
+    // Delete actions always return false to shouldExecute().
     $this->modifyNodes($this->getActions($filtered_elements, 'delete'));
     $this->modifyNodes($this->getRemovedFormElementsDeleteActions($element));
     $this->cleanupNodeRegistry($element);


### PR DESCRIPTION
# What does this Pull Request do?

https://jira.duraspace.org/browse/ISLANDORA-1605

Kills an XML Forms API Bug: When  adding a new form element (like a tab) with children inside, pushing next, then back, removing the added element and trying to push next again, NodeRegistry fails to serialise the element registry. 

This bug is related (more like an improvement) to a previous [pull](https://github.com/Islandora/islandora_xml_forms/pull/199), but deals with different problem. 

Most of current build in XML Forms for solution packs that implement tabbed elements (used mostly for mods namePart) do not define DELETE actions for descendant elements. XML Forms Process Logic handles correctly the removal in the XML Document for elements with a DELETE action but  does not deal with their childs recursively in the registry itself, leaving Orphan elements there that don't have valid XPATHs (because parent is not longer there), needed to serialise the registry when storing our whole metadata step inside the $form_state to allow multi steps: conclusion -> all fails.
# What's new?

You XML Forms can go forward and back without breaking Drupal (and you can add/delete in between)
# How should this be tested?
## before applying the patch:
- Ingest a new object (You can test using the Audio Solution pack)
- Add a new Name tab (fill if you want the fields) 
- Press next
- Have sudden doubts, press back
- Remove the recently added name tab.
- Press next (bum!)
  You will get varying results. This can end in a segment fault, Internal Server error, etc and you will get a blank screen or you can get verbose messages like this
  `Warning: Couldn't fetch DOMElement. Node no longer exists in get_dom_node_xpath_fragment() (line 40 of /var/www/drupal/sites/all/modules/php_lib/DOMHelpers.inc). 
  • Notice: Undefined property: DOMElement::$localName in get_dom_node_xpath_fragment() (line 40 of /var/www/drupal/sites/all/modules/php_lib/DOMHelpers.inc).`
## After applying the patch:

You "should" be able to do any type of adding/removing next back combinations(in types and quantities) and end with a valid XML document and a still valid ingest workflow. I could test a few times and combinations, so it would be great if someone could come with a very strange XML Form to verify edge-edge cases.
# Backwards compatibility:

Nothing broken. 
# Additional Notes:

XML Forms is complicated. The DELETE Logic is also. So i encourage people to test this patch against interactions i could not (like using those one for all mods forms with nested inside nested elements). If it fails i can keep pulling. If someone does not like the code  logic, we can make it more elegant. And please check/compare your resulting XML. Even when the cleanup runs after the XML Document is build operating over the registry, i would like to assure XML is still being produced as expected.
Also interesting is that this BUG is never triggered if you did put a DELETE action to each descendant element, as we really should. (The default one with context self for example). Also if you don't put a DELETE at all for the parent Tab, but this last case makes no sense, because you would end with a lot of "Name" elements for example without the ability to remove them.
# Interest parties:

@rosiel, @ruebot, @nigelgbanks, @Islandora/7-x-1-x-committers and those fine people that reported the problem (Alen Z. and Marko C.) whose github accounts i don't know.

---

Thanks a lot!

Diego Pino Navarro
A dog & human friendly developer
at Metro.org
