### PR TITLE
Fixing some funny behaviour from my last commit.

### DIFF
--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -303,11 +303,35 @@ function xml_form_elements_form_element_tabs_ajax_add(FormElement $element, arra
     if ($element->controls['#type'] == 'tags') {
       foreach ($element->children as $child) {
         $child->default_value = $child->getOriginalDefaultValue();
-        if (empty($child->default_value)) {
+
+        // We should orphan object only if they have no default AND it is not
+        // the last child.  We must retain one, otherwise we'll get AJAX an
+        // AJAX error when adding an element after adding another tab.
+        $no_default = empty($child->default_value);
+        $is_not_last = count($element->children) > 1;
+
+        if ($no_default && $is_not_last) {
           $child->orphan();
         }
       }
+
+      // In order to provide functionality identical to when the tab is first
+      // created, we need to dedeupe based on the first element's default
+      // value.  Otherwise we can wind up with multiples of the same default
+      // value.
+      if (count($element->children > 1)) {
+        $first = array_shift($element->children);
+
+        foreach ($element->children as $child) {
+          if (strcmp($child->default_value, $first->default_value) == 0) {
+            $child->orphan();
+          }
+        }
+
+        array_unshift($element->children, $first);
+      }
     }
+
   };
   $new_tab->eachDecendant($each_function);
   $element->adopt($new_tab);


### PR DESCRIPTION
https://jira.duraspace.org/browse/ISLANDORA-1595
# What does this Pull Request do?

Adds a check before printing out empty tags to the tags template when situated in a tab and a new tab is added.  But really I'm fixing some broken functionality from #212 that I introduced (not having at least one tag produces an AJAX error).  In other words, I DUN GOOFED, AND NOW I SEE WHY @knjackson30974 WAS PRESERVING AT LEAST ONE ELEMENT.  Please allow me to fix my mess without further embarrassment.  Apologies to both @knjackson30974 and @DiegoPino for any inconvenience.  
# How should this be tested?

Open an XML form that has tags within a tab and add some tags. Click to add a new tab and check to see if there are empty tags below the tag field.  Be sure to attempt adding tags to the newly created tab to ensure no AJAX errors are encountered.  
# Background context:

Reported internally a while ago but was still an issue. 
# Additional Notes:
- **Does this change require documentation to be updated?** No
- **Does this change add any new dependencies?** No
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No
- **Could this change impact execution of existing code?** No
# Additional Information

This is a simple addition of a check to the Tags template. 

---

Danny Lamb
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
