### PR TITLE
Acquire default fields (values) from form definition.

### DIFF
--- a/api/XMLForm.inc
+++ b/api/XMLForm.inc
@@ -45,11 +45,13 @@ class XMLForm extends Form {
    *   An array containing an offset of parents.
    */
   public function __construct(array &$form_state, $parents = array(), $name = NULL) {
-    $this->parents = $parents;
-    $this->name = $name;
     parent::__construct(array(), $form_state, $parents);
     if ($this->storage->initialized) {
       $this->initializeFromStorage();
+    }
+    else {
+      $this->parents = $parents;
+      $this->name = $name;
     }
   }
 
@@ -60,6 +62,7 @@ class XMLForm extends Form {
     $this->root = $this->storage->root;
     $this->document = $this->storage->document;
     $this->name = $this->storage->name;
+    $this->parents = $this->storage->parents;
   }
 
   /**
@@ -69,6 +72,7 @@ class XMLForm extends Form {
     $this->storage->root = $this->root;
     $this->storage->document = $this->document;
     $this->storage->name = $this->name;
+    $this->storage->parents = $this->parents;
     $this->storage->initialized = TRUE;
   }
 

--- a/api/XMLForm.inc
+++ b/api/XMLForm.inc
@@ -29,6 +29,13 @@ class XMLForm extends Form {
   protected $parents;
 
   /**
+   * The name of the form from which we were constructed.
+   *
+   * @var string
+   */
+  protected $name;
+
+  /**
    * Constructor function for the XMLForm class.
    *
    * @param array $form_state
@@ -37,8 +44,9 @@ class XMLForm extends Form {
    * @param array $parents
    *   An array containing an offset of parents.
    */
-  public function __construct(array &$form_state, $parents = array()) {
+  public function __construct(array &$form_state, $parents = array(), $name = NULL) {
     $this->parents = $parents;
+    $this->name = $name;
     parent::__construct(array(), $form_state, $parents);
     if ($this->storage->initialized) {
       $this->initializeFromStorage();
@@ -51,6 +59,7 @@ class XMLForm extends Form {
   protected function initializeFromStorage() {
     $this->root = $this->storage->root;
     $this->document = $this->storage->document;
+    $this->name = $this->storage->name;
   }
 
   /**
@@ -59,6 +68,7 @@ class XMLForm extends Form {
   protected function storePersistantMembers() {
     $this->storage->root = $this->root;
     $this->storage->document = $this->document;
+    $this->storage->name = $this->name;
     $this->storage->initialized = TRUE;
   }
 
@@ -182,5 +192,16 @@ class XMLForm extends Form {
       }
     }
     return $flattened;
+  }
+
+  /**
+   * Getter for the form name.
+   *
+   * @return string|NULL
+   *   The name of the form if it was given during instantiation; otherwise,
+   *   NULL.
+   */
+  public function getFormName() {
+    return $this->name;
   }
 }

--- a/builder/xml_form_builder.module
+++ b/builder/xml_form_builder.module
@@ -448,7 +448,7 @@ function xml_form_builder_get_form(array $form, array &$form_state, $form_name, 
     return FALSE;
   }
   try {
-    $xml_form = new XMLForm($form_state, $parents);
+    $xml_form = new XMLForm($form_state, $parents, $form_name);
     // Was not initialized from storage.
     if (!$xml_form->isInitialized()) {
       $definition = new XMLFormDefinition(XMLFormRepository::Get($form_name));

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -288,8 +288,7 @@ function xml_form_elements_form_element_tabs_ajax_alter(FormElement $element, ar
 /**
  * Adds a tabs form element via AJAX.
  *
- * Create new tabs from the original form definition, instead of cloning a
- * "dirty" tab.
+ * Create new tabs from the original form definition.
  *
  * @param FormElement $element
  *   The element to add.

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -310,44 +310,84 @@ function xml_form_elements_form_element_tabs_ajax_add(FormElement $element, arra
   }
 
   // Load up the original form definition using throw-away state.
-  $definition = new XMLFormDefinition(XMLFormRepository::Get($xml_form->getFormName()));
-  $defined_form = $definition->getForm();
-  $empty_form_state = form_state_defaults();
-  drupal_alter(XML_FORM_BUILDER_GET_FORM_MODIFY_DEFINITION_HOOK, $defined_form, $empty_form_state);
+  $form_name = $xml_form->getFormName();
+  if ($form_name !== NULL) {
+    $definition = new XMLFormDefinition(XMLFormRepository::Get($form_name));
+    $defined_form = $definition->getForm();
+    $empty_form_state = form_state_defaults();
+    drupal_alter(XML_FORM_BUILDER_GET_FORM_MODIFY_DEFINITION_HOOK, $defined_form, $empty_form_state);
 
-  // Helper function: Find the tab element.
-  $find_tab_element = function ($form, $offsets) {
-    $target = $form;
-    foreach (array_slice($offsets, 0, -1) as $ancestor) {
-      if (isset($target[$ancestor])) {
-        $target = $target[$ancestor];
-      }
-      else {
-        $children = element_children($target);
-        if (is_numeric($ancestor) && intval($ancestor) == $ancestor && !empty($children)) {
-          // Likely hierarchical things ("tabpanel" in "tabs" or similar)...
-          // Grab the first element.
-          $target = $target[reset($children)];
+    // Helper function: Find the tab element.
+    $find_tab_element = function ($form, $offsets) {
+      $target = $form;
+      foreach (array_slice($offsets, 0, -1) as $ancestor) {
+        if (isset($target[$ancestor])) {
+          $target = $target[$ancestor];
         }
         else {
-          throw new Exception(t('Offset @offset does not exist.', array(
-            '@offset' => $ancestor,
-          )));
+          $children = element_children($target);
+          if (is_numeric($ancestor) && intval($ancestor) == $ancestor && !empty($children)) {
+            // Likely hierarchical things ("tabpanel" in "tabs" or similar)...
+            // Grab the first element.
+            $target = $target[reset($children)];
+          }
+          else {
+            throw new Exception(t('Offset @offset does not exist.', array(
+              '@offset' => $ancestor,
+            )));
+          }
         }
       }
-    }
-    return $target;
-  };
+      return $target;
+    };
 
-  try {
-    $defined_tab_element = $find_tab_element($defined_form, $form_state['triggering_element']['#array_parents']);
-    $tab_element = new FormElement($xml_form->registry, $defined_tab_element);
+    try {
+      $defined_tab_element = $find_tab_element($defined_form, $form_state['triggering_element']['#array_parents']);
+      $tab_element = new FormElement($xml_form->registry, $defined_tab_element);
+    }
+    catch (Exception $e) {
+      watchdog('xml_form_elements', 'Error in Tabs AJAX: @message', array(
+        '@message' => $e->getMessage(),
+      ));
+      return;
+    }
   }
-  catch (Exception $e) {
-    watchdog('xml_form_elements', 'Error in Tabs AJAX: @message', array(
-      '@message' => $e->getMessage(),
-    ));
-    return;
+  else {
+    watchdog('xml_form_elements', 'XMLForm instantiated without form name.', array(), WATCHDOG_WARNING);
+    // No XML Form definition: Direct clone of tab in which "Add" was clicked,
+    // then grabbing the "original" defaults.
+    $tab = $element->findElement($form_state['triggering_element']['#ajax']['params']['child']);
+    $tab_element = clone $tab;
+    $each_function = function ($element) {
+      // Set a FormElement to its default value.
+      $set_to_default = function ($el) {
+        $el->default_value = $el->getOriginalDefaultValue();
+      };
+
+      // Set this one...
+      $set_to_default($element);
+
+      if ($element->controls['#type'] == 'tags') {
+        // ... and make child "tag" elements unique.
+        // First, map 'em all to their defaults.
+        array_map($set_to_default, $element->children);
+
+        // Filter function: Only pass unique values.
+        $child_filter = function ($child) {
+          static $values = array();
+          $value = $child->default_value;
+          if ($value && !in_array($value, $values)) {
+            $values[] = $value;
+            return TRUE;
+          }
+          return FALSE;
+        };
+
+        // Run the filter function.
+        $element->children = array_filter($element->children, $child_filter);
+      }
+    };
+    $tab_element->eachDecendant($each_function);
   }
 
   $element->adopt($tab_element);

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -296,22 +296,87 @@ function xml_form_elements_form_element_tabs_ajax_alter(FormElement $element, ar
  *   The Drupal form state.
  */
 function xml_form_elements_form_element_tabs_ajax_add(FormElement $element, array &$form, array &$form_state) {
-  $tab = $element->findElement($form_state['triggering_element']['#ajax']['params']['child']);
-  $new_tab = clone $tab;
-  $each_function = function ($element) {
-    $element->default_value = $element->getOriginalDefaultValue();
-    if ($element->controls['#type'] == 'tags') {
-      foreach ($element->children as $child) {
-        $child->default_value = $child->getOriginalDefaultValue();
-        if (empty($child->default_value)) {
-          $child->orphan();
+  $xml_form = new XMLForm($form_state);
+  if ($xml_form->isInitialized()) {
+    // Using an XML Form definition: Grab a copy of the first tab, loading up
+    // the original form definition.
+
+    // Load up the original form definition.
+    $definition = new XMLFormDefinition(XMLFormRepository::Get($xml_form->getFormName()));
+    $defined_form = $definition->getForm();
+    $empty_form_state = form_state_defaults();
+    drupal_alter(XML_FORM_BUILDER_GET_FORM_MODIFY_DEFINITION_HOOK, $defined_form, $empty_form_state);
+
+    // Helper function: Find the tab element.
+    $find_tab_element = function ($form, $offsets) {
+      $target = $form;
+      foreach (array_slice($offsets, 0, -1) as $ancestor) {
+        if (isset($target[$ancestor])) {
+          $target = $target[$ancestor];
+        }
+        elseif (is_numeric($ancestor) && intval($ancestor) == $ancestor && isset($target[0])) {
+          // Tabs in tabs... Grab the first, if necessary.
+          $target = $target[0];
+        }
+        else {
+          throw new Exception(t('Offset @offset does not exist.', array(
+            '@offset' => $ancestor,
+          )));
         }
       }
+      return $target;
+    };
+
+    try {
+      $defined_tab_element = $find_tab_element($defined_form, $form_state['triggering_element']['#array_parents']);
+      $tab_element = new FormElement($xml_form->registry, $defined_tab_element);
     }
-  };
-  $new_tab->eachDecendant($each_function);
-  $element->adopt($new_tab);
-  $form[] = $new_tab->toArray();
+    catch (Exception $e) {
+      watchdog('xml_form_elements', 'Error in Tabs AJAX: @message', array(
+        '@message' => $e->getMessage(),
+      ));
+      return;
+    }
+  }
+  else {
+    // No XML Form definition: Direct clone of tab in which "Add" was clicked,
+    // then grabbing the "original" defaults.
+    $tab = $element->findElement($form_state['triggering_element']['#ajax']['params']['child']);
+    $tab_element = clone $tab;
+    $each_function = function ($element) {
+      // Set a FormElement to its default value.
+      $set_to_default = function ($el) {
+        $el->default_value = $el->getOriginalDefaultValue();
+      };
+
+      // Set this one...
+      $set_to_default($element);
+
+      if ($element->controls['#type'] == 'tags') {
+        // ... and make child "tag" elements unique.
+        // First, map 'em all to their defaults.
+        array_map($set_to_default, $element->children);
+
+        // Filter function: Only pass unique values.
+        $child_filter = function ($child) {
+          static $values = array();
+          $value = $child->default_value;
+          if ($value && !in_array($value, $values)) {
+            $values[] = $value;
+            return TRUE;
+          }
+          return FALSE;
+        };
+
+        // Run the filter function.
+        $element->children = array_filter($element->children, $child_filter);
+      }
+    };
+    $tab_element->eachDecendant($each_function);
+  }
+
+  $element->adopt($tab_element);
+  $form[] = $tab_element->toArray();
 }
 
 /**

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -312,10 +312,18 @@ function xml_form_elements_form_element_tabs_ajax_add(FormElement $element, arra
   // Load up the original form definition using throw-away state.
   $form_name = $xml_form->getFormName();
   if ($form_name !== NULL) {
-    $definition = new XMLFormDefinition(XMLFormRepository::Get($form_name));
-    $defined_form = $definition->getForm();
-    $empty_form_state = form_state_defaults();
-    drupal_alter(XML_FORM_BUILDER_GET_FORM_MODIFY_DEFINITION_HOOK, $defined_form, $empty_form_state);
+    $stash_name = 'xml_form_elements_tabs_stash';
+    if (!isset($form_state[$stash_name]) || $form_state[$stash_name]['form_name'] != $form_name) {
+      $definition = new XMLFormDefinition(XMLFormRepository::Get($form_name));
+      // Cache a copy of the originally defined form structure in the form
+      // state.
+      $form_state[$stash_name] = array(
+        'form_name' => $form_name,
+        'original_form' => $definition->getForm(),
+      );
+      $empty_form_state = form_state_defaults();
+      drupal_alter(XML_FORM_BUILDER_GET_FORM_MODIFY_DEFINITION_HOOK, $form_state[$stash_name]['original_form'], $empty_form_state);
+    }
 
     // Helper function: Find the tab element.
     $find_tab_element = function ($form, $offsets) {
@@ -342,7 +350,7 @@ function xml_form_elements_form_element_tabs_ajax_add(FormElement $element, arra
     };
 
     try {
-      $defined_tab_element = $find_tab_element($defined_form, $form_state['triggering_element']['#array_parents']);
+      $defined_tab_element = $find_tab_element($form_state[$stash_name]['original_form'], $form_state['triggering_element']['#array_parents']);
       $tab_element = new FormElement($xml_form->registry, $defined_tab_element);
     }
     catch (Exception $e) {

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -288,6 +288,9 @@ function xml_form_elements_form_element_tabs_ajax_alter(FormElement $element, ar
 /**
  * Adds a tabs form element via AJAX.
  *
+ * Create new tabs from the original form definition, instead of cloning a
+ * "dirty" tab.
+ *
  * @param FormElement $element
  *   The element to add.
  * @param array $form
@@ -297,26 +300,35 @@ function xml_form_elements_form_element_tabs_ajax_alter(FormElement $element, ar
  */
 function xml_form_elements_form_element_tabs_ajax_add(FormElement $element, array &$form, array &$form_state) {
   $xml_form = new XMLForm($form_state);
-  if ($xml_form->isInitialized()) {
-    // Using an XML Form definition: Grab a copy of the first tab, loading up
-    // the original form definition.
 
-    // Load up the original form definition.
-    $definition = new XMLFormDefinition(XMLFormRepository::Get($xml_form->getFormName()));
-    $defined_form = $definition->getForm();
-    $empty_form_state = form_state_defaults();
-    drupal_alter(XML_FORM_BUILDER_GET_FORM_MODIFY_DEFINITION_HOOK, $defined_form, $empty_form_state);
+  if (!$xml_form->isInitialized()) {
+    // XXX: Tabs depend on maintaining the '#hash' values assigned by
+    // objective_forms "Form" objects; however, the "Form" object itself does
+    // not itself maintain the required state, and so is unable to build the
+    // form with the '#hash' values intact.
+    form_error($element->toArray(), t('Using tabs outside of XML forms is not supported.'));
+    return;
+  }
 
-    // Helper function: Find the tab element.
-    $find_tab_element = function ($form, $offsets) {
-      $target = $form;
-      foreach (array_slice($offsets, 0, -1) as $ancestor) {
-        if (isset($target[$ancestor])) {
-          $target = $target[$ancestor];
-        }
-        elseif (is_numeric($ancestor) && intval($ancestor) == $ancestor && isset($target[0])) {
-          // Tabs in tabs... Grab the first, if necessary.
-          $target = $target[0];
+  // Load up the original form definition using throw-away state.
+  $definition = new XMLFormDefinition(XMLFormRepository::Get($xml_form->getFormName()));
+  $defined_form = $definition->getForm();
+  $empty_form_state = form_state_defaults();
+  drupal_alter(XML_FORM_BUILDER_GET_FORM_MODIFY_DEFINITION_HOOK, $defined_form, $empty_form_state);
+
+  // Helper function: Find the tab element.
+  $find_tab_element = function ($form, $offsets) {
+    $target = $form;
+    foreach (array_slice($offsets, 0, -1) as $ancestor) {
+      if (isset($target[$ancestor])) {
+        $target = $target[$ancestor];
+      }
+      else {
+        $children = element_children($target);
+        if (is_numeric($ancestor) && intval($ancestor) == $ancestor && !empty($children)) {
+          // Likely hierarchical things ("tabpanel" in "tabs" or similar)...
+          // Grab the first element.
+          $target = $target[reset($children)];
         }
         else {
           throw new Exception(t('Offset @offset does not exist.', array(
@@ -324,55 +336,19 @@ function xml_form_elements_form_element_tabs_ajax_add(FormElement $element, arra
           )));
         }
       }
-      return $target;
-    };
+    }
+    return $target;
+  };
 
-    try {
-      $defined_tab_element = $find_tab_element($defined_form, $form_state['triggering_element']['#array_parents']);
-      $tab_element = new FormElement($xml_form->registry, $defined_tab_element);
-    }
-    catch (Exception $e) {
-      watchdog('xml_form_elements', 'Error in Tabs AJAX: @message', array(
-        '@message' => $e->getMessage(),
-      ));
-      return;
-    }
+  try {
+    $defined_tab_element = $find_tab_element($defined_form, $form_state['triggering_element']['#array_parents']);
+    $tab_element = new FormElement($xml_form->registry, $defined_tab_element);
   }
-  else {
-    // No XML Form definition: Direct clone of tab in which "Add" was clicked,
-    // then grabbing the "original" defaults.
-    $tab = $element->findElement($form_state['triggering_element']['#ajax']['params']['child']);
-    $tab_element = clone $tab;
-    $each_function = function ($element) {
-      // Set a FormElement to its default value.
-      $set_to_default = function ($el) {
-        $el->default_value = $el->getOriginalDefaultValue();
-      };
-
-      // Set this one...
-      $set_to_default($element);
-
-      if ($element->controls['#type'] == 'tags') {
-        // ... and make child "tag" elements unique.
-        // First, map 'em all to their defaults.
-        array_map($set_to_default, $element->children);
-
-        // Filter function: Only pass unique values.
-        $child_filter = function ($child) {
-          static $values = array();
-          $value = $child->default_value;
-          if ($value && !in_array($value, $values)) {
-            $values[] = $value;
-            return TRUE;
-          }
-          return FALSE;
-        };
-
-        // Run the filter function.
-        $element->children = array_filter($element->children, $child_filter);
-      }
-    };
-    $tab_element->eachDecendant($each_function);
+  catch (Exception $e) {
+    watchdog('xml_form_elements', 'Error in Tabs AJAX: @message', array(
+      '@message' => $e->getMessage(),
+    ));
+    return;
   }
 
   $element->adopt($tab_element);


### PR DESCRIPTION
**Jira:** [ISLANDORA-1559](https://jira.duraspace.org/browse/ISLANDORA-1559) and [ISLANDORA-1595](https://jira.duraspace.org/browse/ISLANDORA-1595)

Supercedes https://github.com/Islandora/islandora_xml_forms/pull/214
# What does this Pull Request do?

Stashes and uses the name of the form in which tabs exist in order to create a new tab from the original form definition, instead of attempting to clone a tab from the form structure as-is and tweak it to look like an original.
# How should this be tested?
1. Create an XML form containing a tabs/tabpanel structure containing a number of defaulted fields including but not limited to tags.
2. When previewing/using the form, new tabpanels added to a tabs(et) should contain the default values for the contained elements. 

There _is_ something of a bizarre edge case, where a tabs(et) is defined containing multiple tabpanels: Deleting and adding tabpanels may result in creating the new tabpanel from an unexpected tabpanel.
# Background context:

This is more of a fix for ISLANDORA-1559... ISLANDORA-1595 seemed to try to treat the symptoms.
# Additional Notes:
- **Does this change require documentation to be updated?** No.
- **Does this change add any new dependencies?** No.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
- **Could this change impact execution of existing code?** Code in the wild which does not specify the form name when instantiating an `XMLForm` will continue to use the "cloning" mechanism. We may want to look at deprecating this behaviour at some point? Though, may be useful if we ever want to make tabs work outside of an XMLForm.

**Tagging:** @DiegoPino (as maintainer)

---

Adam Vessey
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
