### PR TITLE
Rename the datepicker element.

### DIFF
--- a/api/XMLFormDefinition.inc
+++ b/api/XMLFormDefinition.inc
@@ -476,7 +476,10 @@ class XMLFormDefinition {
     $children = $property->children();
     if (count($children) == 0) {
       // If cast fails the string is returned.
-      return cast_string_to_type((string) $property);
+      $type = cast_string_to_type((string) $property);
+      // XXX: This is to handle the renaming of the datepicker element for built
+      // in forms. Remove this at some point.
+      return $type === 'datepicker' ? XML_FORM_ELEMENTS_DATEPICKER_THEME : $type;
     }
     $output = array();
     foreach ($children as $child) {

--- a/elements/includes/Datepicker.inc
+++ b/elements/includes/Datepicker.inc
@@ -56,7 +56,7 @@ class Datepicker {
  * @param array $variables
  *   An array of theming variables.
  */
-function theme_datepicker($variables) {
+function theme_datepicker_xml_form_elements($variables) {
   $element = $variables['element'];
   $array_switch = is_array($element['#value']) && isset($element['#value']['value']);
   $element_val = $array_switch ? $element['#value']['value'] : $element['#value'];

--- a/elements/includes/update.batch.inc
+++ b/elements/includes/update.batch.inc
@@ -14,8 +14,6 @@ function xml_form_elements_rename_datepicker_batch_operation(&$context) {
   $sandbox = &$context['sandbox'];
 
   if (!isset($sandbox['forms'])) {
-    $context['results']['success'] = array();
-    $context['results']['skipped'] = array();
     $sandbox['forms'] = db_select('xml_forms', 'x')
       ->fields('x')
       ->execute()

--- a/elements/includes/update.batch.inc
+++ b/elements/includes/update.batch.inc
@@ -31,7 +31,7 @@ function xml_form_elements_rename_datepicker_batch_operation(&$context) {
   $dom->loadXML($form['form']);
 
   $xpath = new DOMXPath($dom);
-  $results = $xpath->query("//type[text() = 'datepicker']");
+  $results = $xpath->query("//element/properties/type[text() = 'datepicker']");
   if ($results->length > 0) {
     foreach ($results as $element) {
       $element->nodeValue = XML_FORM_ELEMENTS_DATEPICKER_THEME;

--- a/elements/includes/update.batch.inc
+++ b/elements/includes/update.batch.inc
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @file
+ * Batch to update all forms.
+ */
+
+/**
+ * Batch operation to rename all datepicker elements to the new value.
+ *
+ * @param array $context
+ *   An array containing the context of the batch operation.
+ */
+function xml_form_elements_rename_datepicker_batch_operation(&$context) {
+  $sandbox = &$context['sandbox'];
+
+  if (!isset($sandbox['forms'])) {
+    $context['results']['success'] = array();
+    $context['results']['skipped'] = array();
+    $sandbox['forms'] = db_select('xml_forms', 'x')
+      ->fields('x')
+      ->execute()
+      ->fetchAllAssoc('id', PDO::FETCH_ASSOC);
+    if (empty($sandbox['forms'])) {
+      return;
+    }
+  }
+  // Process a form at a time.
+  $form = array_shift($sandbox['forms']);
+  $context['message'] = t('Parsing @form_name for datepicker elements.', array(
+    '@form_name' => $form['name'],
+  ));
+  $dom = new DOMDocument();
+  $dom->loadXML($form['form']);
+
+  $xpath = new DOMXPath($dom);
+  $results = $xpath->query("//type[text() = 'datepicker']");
+  if ($results->length > 0) {
+    foreach ($results as $element) {
+      $element->nodeValue = XML_FORM_ELEMENTS_DATEPICKER_THEME;
+    }
+    db_update('xml_forms')
+      ->fields(array(
+        'form' => $dom->saveXML(),
+      ))
+      ->condition('id', $form['id'])
+      ->execute();
+    drupal_set_message(t('Updated @count elements in @form_name (@form_id) successfully.', array(
+      '@count' => $results->length,
+      '@form_name' => $form['name'],
+      '@form_id' => $form['id'],
+    )));
+  }
+  else {
+    drupal_set_message(t('Skipped @form_name (@form_id) as no occurrences were found.', array(
+      '@form_name' => $form['name'],
+      '@form_id' => $form['id'],
+    )));
+  }
+  $context['finished'] = empty($sandbox['forms']) ? 1 : 0;
+}

--- a/elements/xml_form_elements.install
+++ b/elements/xml_form_elements.install
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @file
+ * Install hooks for the module.
+ */
+
+
+/**
+ * Rename the datepicker element as it collides with another element.
+ */
+function xml_form_elements_update_7001(&$sandbox) {
+  $batch = array(
+    'operations' => array(
+      array('xml_form_elements_rename_datepicker_batch_operation', array()),
+    ),
+    'title' => t('Renaming datepicker element...'),
+    'init_message' => t('Preparing to rename element.'),
+    'progress_message' => t('Time elapsed: @elapsed <br/>Estimated time remaining @estimate.'),
+    'error_message' => t('An error has occurred.'),
+    'file' => drupal_get_path('module', 'xml_form_elements') . '/includes/update.batch.inc',
+    'finished' => 'xml_form_elements_rename_datepicker_batch_finished',
+  );
+  batch_set($batch);
+}

--- a/elements/xml_form_elements.install
+++ b/elements/xml_form_elements.install
@@ -18,7 +18,6 @@ function xml_form_elements_update_7001(&$sandbox) {
     'progress_message' => t('Time elapsed: @elapsed <br/>Estimated time remaining @estimate.'),
     'error_message' => t('An error has occurred.'),
     'file' => drupal_get_path('module', 'xml_form_elements') . '/includes/update.batch.inc',
-    'finished' => 'xml_form_elements_rename_datepicker_batch_finished',
   );
   batch_set($batch);
 }

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -14,7 +14,7 @@ define('XML_FORM_ELEMENTS_TABPANEL_THEME', 'tabpanel');
 define('XML_FORM_ELEMENTS_TAGS_THEME', 'tags');
 define('XML_FORM_ELEMENTS_TAGS_CONTENT_THEME', 'tags_content');
 define('XML_FORM_ELEMENTS_TAG_THEME', 'tag');
-define('XML_FORM_ELEMENTS_DATEPICKER_THEME', 'datepicker');
+define('XML_FORM_ELEMENTS_DATEPICKER_THEME', 'datepicker_xml_form_elements');
 define('XML_FORM_ELEMENTS_PATH', drupal_get_path('module', 'xml_form_elements') . '/');
 define('XML_FORM_ELEMENTS_INCLUDES_PATH', XML_FORM_ELEMENTS_PATH . 'includes/');
 define('XML_FORM_ELEMENTS_JQUERY_THEME_PATH', XML_FORM_ELEMENTS_PATH . 'theme/');
@@ -51,10 +51,10 @@ function xml_form_elements_element_info() {
       '#process' => array('xml_form_elements_tag_process'),
       '#theme' => 'tag',
     ),
-    'datepicker' => array(
+    XML_FORM_ELEMENTS_DATEPICKER_THEME => array(
       '#input' => TRUE,
-      '#process' => array('xml_form_elements_datepicker_process'),
-      '#theme' => 'datepicker',
+      '#process' => array('xml_form_elements_datepicker_xml_form_elements_process'),
+      '#theme' => XML_FORM_ELEMENTS_DATEPICKER_THEME,
       '#theme_wrappers' => array('form_element'),
     ),
     'defaultable_markup' => array(
@@ -240,7 +240,7 @@ function xml_form_elements_tag_process($element, &$form_state, $complete_form) {
  * @return array
  *   The processed element.
  */
-function xml_form_elements_datepicker_process($element, &$form_state, $complete_form) {
+function xml_form_elements_datepicker_xml_form_elements_process($element, &$form_state, $complete_form) {
   form_load_include($form_state, 'inc', 'xml_form_elements', 'includes/Datepicker');
   return Datepicker::Process($element, $form_state, $complete_form);
 }

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -14,6 +14,9 @@ define('XML_FORM_ELEMENTS_TABPANEL_THEME', 'tabpanel');
 define('XML_FORM_ELEMENTS_TAGS_THEME', 'tags');
 define('XML_FORM_ELEMENTS_TAGS_CONTENT_THEME', 'tags_content');
 define('XML_FORM_ELEMENTS_TAG_THEME', 'tag');
+// XXX: Defining this with the module name as the suffix as ExtJS cuts off
+// the display of elements over certain characters. Similarly, the element
+// listing is sorted alphabetically.
 define('XML_FORM_ELEMENTS_DATEPICKER_THEME', 'datepicker_xml_form_elements');
 define('XML_FORM_ELEMENTS_PATH', drupal_get_path('module', 'xml_form_elements') . '/');
 define('XML_FORM_ELEMENTS_INCLUDES_PATH', XML_FORM_ELEMENTS_PATH . 'includes/');


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1655
# What does this Pull Request do?

Renames the datepicker element to be unique to formbuilder as well as updates all forms in the database.
# What's new?

While the update hook will handle all forms built through the UI (stored in the database) the ones "Built in" (provided by modules) will continue to have the datepicker element present in them. There are none of these in core. With that in mind if a datepicker type is encountered it's being replaced with the new element for the time being.
# How should this be tested?

Create a form through the UI with a datepicker element.
Have a "Built in" form present with a datepicker element.
Run the update included in this module and note that the element type has changed and all other functionality operates as expected.
For the built in form the element type gets changed before it's rendered to the screen and all functionality should remain equal.
# Release notes

This change will update all forms in the database and handle any encounters of formbuilder forms being loaded up through xml_form_builder. However, any custom modules that are utilizing a form element of `'#type' => 'datepicker'` will have a loss of functionality as this element has been renamed to no longer collide with one provided Drupal contrib's [Datepicker](https://www.drupal.org/project/datepicker) module. There are two options that can be undertook to fix these:
1. Change the `'#type'` from `'datepicker'` to the `XML_FORM_ELEMENTS_DATEPICKER_THEME` value
   OR
2. Add the date_popup module as a dependency and change the `'#type'` from `'datepicker'` to `'date_popup'`. The date_popup module uses the same jQuery library as formbuilder but provides some additional functionality that can be specified such as a date format, a timepicker etc. To keep the functionality identical to the formbuilder datepicker element the following options should be set:

``` php
'#type' => 'date_popup',
'#timepicker' => FALSE,
'#date_format' => 'Y-m-d',
```
# Interested parties

@DiegoPino 
