### PR TITLE
Remove Unnecessary Escaping for Tags

### DIFF
--- a/elements/includes/Tag.inc
+++ b/elements/includes/Tag.inc
@@ -58,7 +58,7 @@ class Tag {
     $tags = &get_form_element_parent($element, $complete_form);
     $element['#id'] = $element['#hash'];
     $element['#title'] = isset($tags['#title']) ? $tags['#title'] : FALSE;
-    $element['#value'] = isset($element['#value']) ? check_plain($element['#value']) : FALSE;
+    $element['#value'] = isset($element['#value']) ? $element['#value'] : FALSE;
     return $element;
   }
 }

--- a/elements/templates/Tags.tpl.php
+++ b/elements/templates/Tags.tpl.php
@@ -21,7 +21,7 @@
   <span class="tag-list">
     <?php foreach ($tags as $tag): ?>
       <span title="<?php print "{$tag['#value']}" ?>">
-        <span class="edit-tag" onclick="jQuery('#<?php print $edit[$tag['#hash']]['#id'] ?>').trigger('mousedown'); return false;"><?php print decode_entities("{$tag['#value']}") ?></span>
+        <span class="edit-tag" onclick="jQuery('#<?php print $edit[$tag['#hash']]['#id'] ?>').trigger('mousedown'); return false;"><?php print check_plain("{$tag['#value']}") ?></span>
         <span class="remove-tag" onclick="jQuery('#<?php print $remove[$tag['#hash']]['#id'] ?>').trigger('mousedown'); return false;"></span>
       </span>
     <?php endforeach ?>


### PR DESCRIPTION
Jira: https://jira.duraspace.org/browse/ISLANDORA-1750
# **What does this Pull Request do?**

Islandora XML Forms Introduces unnecessary escaping for the tag field.

1) This PR fixes that unnecessary escaping. 
2) Also fixes MODS record in the process because it originally escaped twice too. 
# **How should this be tested?**

Steps to Reproduce:

1) Islandora edits an Object's MODS Datastream. 
2) Change a Subject Topic to something with an ampersand. 
3) Save the record. 
4) Edit the record again.  The ampersand is now HTML encoded as &amp;  Subsequent saves will double encode the character.

![image](https://cloud.githubusercontent.com/assets/7623298/16391712/4f85674c-3c76-11e6-9d73-b157f1c5dbda.png)

![image](https://cloud.githubusercontent.com/assets/7623298/16391727/6b7ad8b0-3c76-11e6-92f2-4526620f2b8b.png)

We were unable to find a valid need for the check_plain call. Can you explain if there was something we missed? 
