### PR TITLE
Include the correct file.

### DIFF
--- a/api/schema/Extension.inc
+++ b/api/schema/Extension.inc
@@ -6,7 +6,7 @@
  */
 
 module_load_include('inc', 'php_lib', 'DOMHelpers');
-module_load_include('inc', 'schema  _api', 'Any');
+module_load_include('inc', 'xml_schema_api', 'Any');
 module_load_include('inc', 'xml_schema_api', 'Choice');
 module_load_include('inc', 'xml_schema_api', 'Sequence');
 module_load_include('inc', 'xml_schema_api', 'Group');


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/projects/ISLANDORA/issues/ISLANDORA-1757
- Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
  https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/islandora/Ab7wL8mmzJI
# What does this Pull Request do?

Correctly spells the module_load_include so that it's found.
# What's new?

Includes the correct file.
# How should this be tested?

On a Drupal 7.50 install the bootstrap message of 
`The following module is missing from the file system: <em class="placeholder">schema  _api</em>. In order to fix this, put the module back in its original location. For more information, see <a href="https://www.drupal.org/node/2487215">the documentation page</a>. bootstrap.inc:1128` no longer appears.
# Interested parties

@DiegoPino 
