### PR TITLE
Alter islandora_cleanup_mods_extended.xsl to respect MODS ordering co…

### DIFF
--- a/builder/self_transforms/islandora_cleanup_mods_extended_strict.xsl
+++ b/builder/self_transforms/islandora_cleanup_mods_extended_strict.xsl
@@ -14,8 +14,6 @@
             <xsl:apply-templates select="@*[normalize-space()]"/>
             <xsl:apply-templates select="mods:languageTerm"/>
             <xsl:apply-templates select="mods:scriptTerm"/>
-            <!-- Do not strip any custom elements. -->
-            <xsl:apply-templates select="node()[not(self::mods:languageTerm|self::mods:scriptTerm)]"/>
         </xsl:copy>
     </xsl:template>
     <xsl:template match="mods:location">
@@ -26,8 +24,6 @@
             <xsl:apply-templates select="mods:url"/>
             <xsl:apply-templates select="mods:holdingSimple"/>
             <xsl:apply-templates select="mods:holdingExternal"/>
-            <!-- Do not strip any custom elements. -->
-            <xsl:apply-templates select="node()[not(self::mods:physicalLocation|self::mods:shelfLocator|self::mods:url|self::mods:holdingSimple|self::mods:holdingExternal)]"/>
         </xsl:copy>
     </xsl:template>
     <xsl:template match="mods:copyInformation">
@@ -40,8 +36,6 @@
             <xsl:apply-templates select="mods:note"/>
             <xsl:apply-templates select="mods:enumerationAndChronology"/>
             <xsl:apply-templates select="mods:itemIdentifier"/>
-            <!-- Do not strip any custom elements. -->
-            <xsl:apply-templates select="node()[not(self::mods:form|self::mods:subLocation|self::mods:shelfLocator|self::mods:electronicLocator|self::mods:note|self::mods:enumerationAndChronology|self::mods:itemIdentifier)]"/>
         </xsl:copy>
     </xsl:template>
     <!--
@@ -55,7 +49,6 @@
         <xsl:copy>
             <xsl:apply-templates select="@*[normalize-space()]"/>
             <xsl:apply-templates select="mods:etal"/>
-            <!-- Do not strip any custom elements. -->
             <xsl:apply-templates select="node()[not(self::mods:etal)]"/>
         </xsl:copy>
     </xsl:template>
@@ -70,8 +63,6 @@
             <xsl:apply-templates select="mods:end"/>
             <xsl:apply-templates select="mods:total"/>
             <xsl:apply-templates select="mods:list"/>
-            <!-- Do not strip any custom elements. -->
-            <xsl:apply-templates select="node()[not(self::mods:start|self::mods:end|self::mods:total|self::mods:list)]"/>
         </xsl:copy>
     </xsl:template>
     <xsl:template match="mods:cartographics">
@@ -81,8 +72,6 @@
             <xsl:apply-templates select="mods:projection"/>
             <xsl:apply-templates select="mods:coordinates"/>
             <xsl:apply-templates select="mods:cartographicExtension"/>
-            <!-- Do not strip any custom elements. -->
-            <xsl:apply-templates select="node()[not(self::mods:scale|self::mods:projection|self::mods:coordinates|self::mods:cartographicExtension)]"/>
         </xsl:copy>
     </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-1803)
# What does this Pull Request do?

Changes the extended cleanup self transform to apply ordering constraints in particular for the children of the elements (Version 3.6):
- mods:language
- mods:location
- mods:copyInformation
- mods:name (When using the mods:etal form).
- mods:extent
- mods:cartographics
# What's new?

Just changes the to the transform mentioned above.
# How should this be tested?

Create a simple MODS form that places the aforementioned elements out of order, and use the    self transform in the forms declaration to correctly re-order the elements before writing to fedora.
# Additional Notes:

This will have some unintended side effects for those using this transform on non valid MODS Documents. If anyone out there is embedded elements custom elements in either: 
- mods:language
- mods:location
- mods:copyInformation
- mods:name (When using the mods:etal form).
- mods:extent
- mods:cartographics

Those custom elements would get stripped by this transform. One would assume though that if folks needed custom elements they would use mods:extension.
# Interested parties

@Islandora/7-x-1-x-committers
