### PR TITLE
Addresses https://jira.duraspace.org/browse/ISLANDORA-1849

### DIFF
--- a/api/Create.inc
+++ b/api/Create.inc
@@ -190,7 +190,7 @@ class Create implements ActionInterface {
       self::XML => 'createXML',
     );
     try {
-      return $this->$action[$this->type]($document, $value);
+      return $this->{$action[$this->type]}($document, $value);
     }
     catch (Exception $e) {
       $value = htmlentities($this->value);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1849

# What does this Pull Request do?

Allows Islandora XML Forms to be compatible with PHP 7

# What's new?
Some curly braces.

# How should this be tested?

Run Islandora under PHP 7, and edit the metadata on an object, click save, and you should get an error on the screen, the log should read something along the lines of:

```
Error: Call to undefined function createXML() in Create->doCreate() (line 193 of /var/www/digital.library.yorku.ca/sites/all/modules/islandora_xml_forms/api/Create.inc).
```

# Interested parties
@DiegoPino and any other @Islandora/7-x-1-x-committers

