### PR TITLE
Fix tests so they will run in any path

### DIFF
--- a/tests/islandora_xml_forms_associate.test
+++ b/tests/islandora_xml_forms_associate.test
@@ -89,13 +89,14 @@ class IslandoraXMLFormAssociationTestCase extends IslandoraCollectionWebTestCase
    * Create a new form association with several controlled customizations.
    */
   public function testFormAssociationCreate() {
+    $module_path = drupal_get_path('module', 'xml_forms');
 
     // Prep for this test by copying the test xslt transformations and pasting
     // them into their respective XML Form Builder transform folders.
     $this->custom_transform_filename = "{$this->randomName()}.xsl";
     $this->self_transform_filename = "{$this->randomName()}.xsl";
-    file_unmanaged_copy(drupal_get_path('module', 'xml_forms') . "/tests/islandora_solution_pack_test/xsl/mods_to_dc_custom.xsl", "sites/all/modules/islandora_xml_forms/builder/transforms/$this->custom_transform_filename");
-    file_unmanaged_copy(drupal_get_path('module', 'xml_forms') . "/tests/islandora_solution_pack_test/xsl/self_transform.xsl", "sites/all/modules/islandora_xml_forms/builder/self_transforms/$this->self_transform_filename");
+    file_unmanaged_copy($module_path . "/tests/islandora_solution_pack_test/xsl/mods_to_dc_custom.xsl", $module_path . "/builder/transforms/$this->custom_transform_filename");
+    file_unmanaged_copy($module_path . "/tests/islandora_solution_pack_test/xsl/self_transform.xsl", $module_path . "/builder/self_transforms/$this->self_transform_filename");
 
     // Attempt to fill out and submit the form association form.
     $this->dsid = $this->randomName();


### PR DESCRIPTION
**JIRA Ticket**: 

https://jira.duraspace.org/browse/ISLANDORA-1865

# What does this Pull Request do?

XML Forms tests won't run unless it is installed at: 
/sites/all/modules/islandora_xml_forms

Pull request uses drupal_get_path to avoid this.

# What's new?

Use drupal_get_path instead of a fixed path.

# How should this be tested?

Make sure tests still run.

# Interested parties
@DiegoPino @nigelgbanks 