### PR TITLE
Fix database schema

### DIFF
--- a/builder/xml_form_builder.install
+++ b/builder/xml_form_builder.install
@@ -38,31 +38,31 @@ function xml_form_builder_schema() {
     'fields' => array(
       'id' => array(
         'type' => 'serial',
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
       'content_model' => array(
         'description' => 'The name of the content model.',
         'type' => 'varchar',
         'length' => 128,
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
       'form_name' => array(
         'description' => 'The name of the stored form.',
         'type' => 'varchar',
         'length' => 128,
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
       'dsid' => array(
         'description' => 'The datastream ID of the metadata to be edited.',
         'type' => 'varchar',
         'length' => 128,
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
       'title_field' => array(
         'description' => 'The form field for the object\'s label.',
         'type' => 'varchar',
         'length' => 256,
-        'not NULL' => FALSE,
+        'not null' => FALSE,
         'binary' => TRUE,
         'serialize' => TRUE,
       ),
@@ -70,19 +70,19 @@ function xml_form_builder_schema() {
         'description' => 'An XSL transform for setting the Fedora object\'s Dublin Core metadata datastream.',
         'type' => 'varchar',
         'length' => 128,
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
       'self_transform' => array(
         'description' => 'A xsl transform for setting the Fedora Object\'s Dublin Core metadata datastream.',
         'type' => 'varchar',
         'length' => 128,
-        'not NULL' => FALSE,
+        'not null' => FALSE,
       ),
       'template' => array(
         'description' => 'A sample metadata file used to prepopulate the form on ingest.',
         'type' => 'text',
         'size' => 'medium',
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
     ),
     'primary key' => array('id'),
@@ -94,13 +94,13 @@ function xml_form_builder_schema() {
         'description' => 'The name of the hook.',
         'type' => 'varchar',
         'length' => 128,
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
       'enabled' => array(
         'description' => 'The hook\'s status (enabled or not).',
         'type' => 'int',
         'size' => 'tiny',
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
     ),
     'primary key' => array('id'),
@@ -117,13 +117,13 @@ function xml_form_builder_schema() {
         'description' => 'The name of the XSLT.',
         'type' => 'varchar',
         'length' => 255,
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
       'xslt' => array(
         'description' => 'An XSLT.',
         'type' => 'text',
         'size' => 'big',
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
     ),
     'unique keys' => array('name' => array('name')),
@@ -141,24 +141,24 @@ function xml_form_builder_schema() {
         'description' => 'The name of the content model.',
         'type' => 'varchar',
         'length' => 128,
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
       'name' => array(
         'description' => 'The name of the mapping.',
         'type' => 'varchar',
         'length' => 255,
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
       'xslt_id' => array(
         'description' => 'An XSLT id.',
         'type' => 'int',
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
       'dsid' => array(
         'description' => 'The datastream ID of the metadata to be edited.',
         'type' => 'varchar',
         'length' => 128,
-        'not NULL' => TRUE,
+        'not null' => TRUE,
       ),
     ),
     'foreign keys' => array(
@@ -483,5 +483,140 @@ function xml_form_builder_update_7105() {
           ->execute();
       }
     }
+  }
+}
+
+/**
+ * Update fields to have not NULL.
+ *
+ * Had a syntax error in our schema.
+ */
+function xml_form_builder_update_7106() {
+  db_change_field('xml_form_builder_form_associations', 'id', 'id',
+    array(
+      'type' => 'serial',
+      'not null' => TRUE,
+    )
+  );
+  db_change_field('xml_form_builder_form_associations', 'content_model', 'content_model',
+    array(
+      'description' => 'The name of the content model.',
+      'type' => 'varchar',
+      'length' => 128,
+      'not null' => TRUE,
+    )
+  );
+  db_change_field('xml_form_builder_form_associations', 'form_name', 'form_name',
+    array(
+      'description' => 'The name of the stored form.',
+      'type' => 'varchar',
+      'length' => 128,
+      'not null' => TRUE,
+    )
+  );
+  db_change_field('xml_form_builder_form_associations', 'dsid', 'dsid',
+    array(
+      'description' => 'The datastream ID of the metadata to be edited.',
+      'type' => 'varchar',
+      'length' => 128,
+      'not null' => TRUE,
+    )
+  );
+  db_change_field('xml_form_builder_form_associations', 'transform', 'transform',
+    array(
+      'description' => 'An XSL transform for setting the Fedora object\'s Dublin Core metadata datastream.',
+      'type' => 'varchar',
+      'length' => 128,
+      'not null' => TRUE,
+    )
+  );
+  db_change_field('xml_form_builder_form_associations', 'template', 'template',
+    array(
+      'description' => 'A sample metadata file used to prepopulate the form on ingest.',
+      'type' => 'text',
+      'size' => 'medium',
+      'not null' => TRUE,
+    )
+  );
+
+  db_change_field('xml_form_builder_association_hooks', 'id', 'id',
+    array(
+      'description' => 'The name of the hook.',
+      'type' => 'varchar',
+      'length' => 128,
+      'not null' => TRUE,
+    )
+  );
+  db_change_field('xml_form_builder_association_hooks', 'enabled', 'enabled',
+    array(
+      'description' => 'The hook\'s status (enabled or not).',
+      'type' => 'int',
+      'size' => 'tiny',
+      'not null' => TRUE,
+    )
+  );
+
+  db_change_field('xml_form_builder_xslts', 'name', 'name',
+    array(
+      'description' => 'The name of the XSLT.',
+      'type' => 'varchar',
+      'length' => 255,
+      'not null' => TRUE,
+    )
+  );
+  db_change_field('xml_form_builder_xslts', 'xslt', 'xslt',
+    array(
+      'description' => 'An XSLT.',
+      'type' => 'text',
+      'size' => 'big',
+      'not null' => TRUE,
+    )
+  );
+  db_change_field('xml_form_builder_xslts', 'xslt_id', 'xslt_id',
+    array(
+      'type' => 'serial',
+      'not null' => TRUE,
+    )
+  );
+
+  db_change_field('xml_form_builder_default_xslts', 'content_model', 'content_model',
+    array(
+      'description' => 'The name of the content model.',
+      'type' => 'varchar',
+      'length' => 128,
+      'not null' => TRUE,
+    )
+  );
+  db_change_field('xml_form_builder_default_xslts', 'name', 'name',
+    array(
+      'description' => 'The name of the mapping.',
+      'type' => 'varchar',
+      'length' => 255,
+      'not null' => TRUE,
+    )
+  );
+  db_change_field('xml_form_builder_default_xslts', 'xslt_id', 'xslt_id',
+    array(
+      'description' => 'An XSLT id.',
+      'type' => 'int',
+      'not null' => TRUE,
+    )
+  );
+  db_change_field('xml_form_builder_default_xslts', 'dsid', 'dsid',
+    array(
+      'description' => 'The datastream ID of the metadata to be edited.',
+      'type' => 'varchar',
+      'length' => 128,
+      'not null' => TRUE,
+    )
+  );
+
+  $db_type = db_driver();
+
+  if ($db_type == 'pgsql') {
+    // XXX: https://www.drupal.org/node/190027.
+    db_add_primary_key('xml_form_builder_form_associations', array('id'));
+    db_add_primary_key('xml_form_builder_association_hooks', array('id'));
+    db_add_primary_key('xml_form_builder_xslts', array('xslt_id'));
   }
 }


### PR DESCRIPTION
**JIRA Ticket**: 
https://jira.duraspace.org/browse/ISLANDORA-1884

# What does this Pull Request do?

When enabling xml_form_builder running MySQL 5.7 we get:
```
$ drush en xml_form_builder

The following extensions will be enabled: xml_form_builder
Do you really want to continue? (y/n): y
WD php: PDOException: SQLSTATE[42000]: Syntax error or access violation: 1171 All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use      [error]
UNIQUE instead: CREATE TABLE {xml_form_builder_form_associations} (
`id` INT auto_increment DEFAULT NULL, 
`content_model` VARCHAR(128) DEFAULT NULL COMMENT 'The name of the content model.', 
`form_name` VARCHAR(128) DEFAULT NULL COMMENT 'The name of the stored form.', 
`dsid` VARCHAR(128) DEFAULT NULL COMMENT 'The datastream ID of the metadata to be edited.', 
`title_field` VARCHAR(256) BINARY DEFAULT NULL COMMENT 'The form field for the object’s label.', 
`transform` VARCHAR(128) DEFAULT NULL COMMENT 'An XSL transform for setting the Fedora object’s Dublin Core metadata datastream.', 
`self_transform` VARCHAR(128) DEFAULT NULL COMMENT 'A xsl transform for setting the Fedora Object’s Dublin Core metadata datastream.', 
`template` MEDIUMTEXT DEFAULT NULL COMMENT 'A sample metadata file used to prepopulate the form on ingest.', 
PRIMARY KEY (`id`)
) ENGINE = InnoDB DEFAULT CHARACTER SET utf8 COMMENT 'This table is used to store associations between XML Form...'; Array
(
)
 in db_create_table() (line 2776 of /var/www/drupal/includes/database/database.inc).
```

Looks like we already tried to define the primary key as `not null` but we had an error where we used `not NULL`. This was being ignored due to case, causing it to allow nulls which MySQL did not like in newer versions.

# What's new?

Changes the scheme to use the correct case for `not NULL` and defines an update hook to fix existing sites.

# How should this be tested?

* On a box with MySQL 5.7 enable the module and make sure it works. 

* On a box with MySQL 5.5 enable the module without this patch. 
  * Create form associations.
  * Apply patch. 
  * Run update and make sure database is correctly updated.

# Interested parties
@DiegoPino @nigelgbanks 