### PR TITLE
Fix Form Definition creation in PHP7

### DIFF
--- a/api/XMLFormDefinition.inc
+++ b/api/XMLFormDefinition.inc
@@ -658,7 +658,7 @@ class XMLFormDefinitionGenerator {
       }
     }
     else {
-      $property->{0} = cast_type_to_string($value);
+      $property[0] = cast_type_to_string($value);
     }
   }
 


### PR DESCRIPTION
**JIRA Ticket**:

https://jira.duraspace.org/browse/ISLANDORA-1886

# What does this Pull Request do?

Using PHP7 you cannot modify Form Builder forms. It gives an error about bad form definition. This pull request restores the ability to modify forms when using PHP7.

Error message:
```
File: /var/www/drupal/sites/all/modules/islandora/islandora_xml_forms/api/XMLFormDefinition.inc
Line: 256
Error: XML form definition is not valid.
```

# What's new?

In PHP5 you could add a text node to a SimpleXmlElement using the syntax `$element->{0} = 'my text'`. This would result in: `<element>my text</element>`.

In PHP7 this gives (the invalid XML): `<element><0>my text</0></element>`. DomDocument chokes on this invalid XML when its imported and then everything falls apart.

Instead in PHP7 you need to use `$element[0] = 'my text'` this results in the correct XML in both PHP5 and PHP7.

# How should this be tested?

* PHP5 and PHP7
  * Try to edit form definition without patch
  * Try to edit and save form definition after patch

# Interested parties
@Islandora/7-x-1-x-committers @DiegoPino 