### PR TITLE
ISLANDORA-1888 Add list of enabled associations.

### DIFF
--- a/builder/ListAssociations.inc
+++ b/builder/ListAssociations.inc
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @file
+ * Callbacks and functions for the Main Page.
+ */
+
+/**
+ * Show the Associations page.
+ *
+ * Here, the user can view which forms are enabled for each content model.
+ *
+ * @return array
+ *   The table to display.
+ */
+function xml_form_builder_list_associations() {
+
+  module_load_include('inc', 'xml_form_builder', 'includes/associations');
+
+  $associations_list = array(
+    '#theme'=> 'item_list',
+    '#items' => array(),
+  );
+
+  $associations = xml_form_builder_get_associations(array(), array(), array(), TRUE);
+  $map = array();
+
+  foreach($associations as $association) {
+    $cmodel = $association['content_model'];
+    $form = $association['form_name'];
+    if (!isset($map[$cmodel])) {
+      $map[$cmodel] = array();
+    }
+    $map[$cmodel][] = $form;
+  }
+  ksort($map);
+
+  function association_table_rows($form){
+    return array(l($form, xml_form_builder_get_associate_form_path($form)));
+  }
+
+  foreach ($map as $cmodel => $forms) {
+    $form_table = array(
+      '#theme' => 'table',
+      '#rows' => array_map('association_table_rows', $forms),
+    );
+    $object = islandora_object_load($cmodel);
+    if ($object) {
+      $label =  $object->label . " ($cmodel)";
+    }
+    else {
+      $label = $cmodel;
+    }
+    $associations_list['#items'][] = $label  . drupal_render($form_table);
+
+  }
+
+  return array($associations_list);
+}

--- a/builder/ListAssociations.inc
+++ b/builder/ListAssociations.inc
@@ -18,14 +18,14 @@ function xml_form_builder_list_associations() {
   module_load_include('inc', 'xml_form_builder', 'includes/associations');
 
   $associations_list = array(
-    '#theme'=> 'item_list',
+    '#theme' => 'item_list',
     '#items' => array(),
   );
 
   $associations = xml_form_builder_get_associations(array(), array(), array(), TRUE);
   $map = array();
 
-  foreach($associations as $association) {
+  foreach ($associations as $association) {
     $cmodel = $association['content_model'];
     $form = $association['form_name'];
     if (!isset($map[$cmodel])) {
@@ -35,24 +35,26 @@ function xml_form_builder_list_associations() {
   }
   ksort($map);
 
-  function association_table_rows($form){
-    return array(l($form, xml_form_builder_get_associate_form_path($form)));
+  /**
+   * Returns a link to the edit associations form for form $form_name.
+   */
+  function create_form_association_link($form_name) {
+    return array(l($form_name, xml_form_builder_get_associate_form_path($form_name)));
   }
 
   foreach ($map as $cmodel => $forms) {
     $form_table = array(
       '#theme' => 'table',
-      '#rows' => array_map('association_table_rows', $forms),
+      '#rows' => array_map('create_form_association_link', $forms),
     );
     $object = islandora_object_load($cmodel);
     if ($object) {
-      $label =  $object->label . " ($cmodel)";
+      $label = $object->label . " ($cmodel)";
     }
     else {
       $label = $cmodel;
     }
-    $associations_list['#items'][] = $label  . drupal_render($form_table);
-
+    $associations_list['#items'][] = $label . drupal_render($form_table);
   }
 
   return array($associations_list);

--- a/builder/ListAssociations.inc
+++ b/builder/ListAssociations.inc
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Callbacks and functions for the Main Page.
+ * Callbacks and functions for the Associations Page.
  */
 
 /**

--- a/builder/xml_form_builder.module
+++ b/builder/xml_form_builder.module
@@ -14,6 +14,7 @@ define('XML_FORM_BUILDER_ASSOCIATE_FORMS_PERMS', 'Associate XML Forms');
 
 define('XML_FORM_BUILDER_ADMIN_MENU', 'admin/islandora/xmlform');
 define('XML_FORM_BUILDER_MAIN_MENU', XML_FORM_BUILDER_ADMIN_MENU . '/forms');
+define('XML_FORM_BUILDER_ASSOCIATIONS', XML_FORM_BUILDER_ADMIN_MENU . '/associations');
 define('XML_FORM_BUILDER_SETTINGS_MENU', XML_FORM_BUILDER_ADMIN_MENU . '/settings');
 define('XML_FORM_BUILDER_XSLTS_MENU', XML_FORM_BUILDER_ADMIN_MENU . '/xslts');
 define('XML_FORM_BUILDER_ADD_XSLTS_MENU', XML_FORM_BUILDER_XSLTS_MENU . '/add_xslt');
@@ -74,6 +75,16 @@ function xml_form_builder_menu() {
     'page callback' => 'xml_form_builder_main',
     'access arguments' => array(XML_FORM_BUILDER_LIST_FORMS_PERMS),
     'type' => MENU_DEFAULT_LOCAL_TASK,
+    'weight' => 0,
+  );
+  $items[XML_FORM_BUILDER_ASSOCIATIONS] = array(
+    'title' => 'Enabled Associations',
+    'description' => 'View form associations by content model',
+    'file' => 'ListAssociations.inc',
+    'page callback' => 'xml_form_builder_list_associations',
+    'access arguments' => array(XML_FORM_BUILDER_LIST_FORMS_PERMS),
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 1,
   );
   $items[XML_FORM_BUILDER_SETTINGS_MENU] = array(
     'title' => 'Settings',
@@ -82,6 +93,7 @@ function xml_form_builder_menu() {
     'page arguments' => array('xml_form_builder_settings_form'),
     'access arguments' => array(XML_FORM_BUILDER_ASSOCIATE_FORMS_PERMS),
     'type' => MENU_LOCAL_TASK,
+    'weight' => 2,
   );
   $items[XML_FORM_BUILDER_XSLTS_MENU] = array(
     'title' => 'XSLTs',


### PR DESCRIPTION
**JIRA Ticket**:  https://jira.duraspace.org/browse/ISLANDORA-1888

# What does this Pull Request do?

Shows what active associations exist by content model.

# What's new?
Added a new admin page in the menu at admin/islandora/xmlform/associations, which displays associated forms per content model. 

# How should this be tested?

Enable, and clear cache, and go to admin/islandora/xmlform/associations. 

# Additional Notes:

* Does this change require documentation to be updated? Yes. 
* Does this change add any new dependencies?  No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? No.

# Interested parties
@Islandora/7-x-1-x-committers
