### PR TITLE
Parental offset for tabpanels that may exist inside an embedded form.

### DIFF
--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -329,9 +329,12 @@ function xml_form_elements_form_element_tabs_ajax_add(FormElement $element, arra
     }
 
     // Helper function: Find the tab element.
-    $find_tab_element = function ($form, $offsets) {
+    $find_tab_element = function ($form, $offsets) use ($xml_form) {
       $target = $form;
-      foreach (array_slice($offsets, 0, -1) as $ancestor) {
+      // XXX: Use the parents here for an offset count as it is technically
+      // possible to embed an Islandora XML Form Builder form within another
+      // Drupal form.
+      foreach (array_slice($offsets, count($xml_form->root->getParentsArray()), -1) as $ancestor) {
         if (isset($target[$ancestor])) {
           $target = $target[$ancestor];
         }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2025

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
Former pull request and its two related JIRA tickets:

- https://github.com/Islandora/islandora_xml_forms/pull/217
- https://jira.duraspace.org/browse/ISLANDORA-1559
- https://jira.duraspace.org/browse/ISLANDORA-1595

# What does this Pull Request do?

Fixes a bit of a regression such that an Islandora XML Form Builder form embedded within another form has the CRUD for tabpanels work as expected.

# What's new?
A parental offset is being used to find the triggering tabpanel element as opposed to a static 0 offset.

# How should this be tested?
Have a form with a tabpanel.
Do CRUD operations with the tabpanel.
Behavior is the same as before this pull.

# Interested parties
@Islandora/7-x-1-x-committers, @DiegoPino 
