### PR TITLE
ISLANDORA-2105: Fix CMODEL associations when default transforms are enabled

### DIFF
--- a/builder/includes/associations.form.inc
+++ b/builder/includes/associations.form.inc
@@ -30,7 +30,7 @@ function xml_form_builder_associations_form(array $form, array &$form_state, $fo
   form_load_include($form_state, 'inc', 'xml_form_builder', 'includes/associations.form');
 
   $associations = xml_form_builder_get_associations(array($form_name), array(), array(), FALSE);
-  $create_table_rows = function($association) {
+  $create_table_rows = function ($association) {
     if (is_array($association['title_field'])) {
       $association['title_field'] = "['" . implode("']['", $association['title_field']) . "']";
     }
@@ -131,6 +131,13 @@ function xml_form_builder_associations_form_submit(array $form, array &$form_sta
     'transform',
     'self_transform',
   );
+  // If default XLST used, these form state values will not be present.
+  if (variable_get('xml_form_builder_use_default_dc_xslts', FALSE)) {
+    // 'No Transform' is the default used in the form.
+    $form_state['values']['transform'] = 'No Transform';
+    $form_state['values']['self_transform'] = 'No Transform';
+  }
+
   $object = array_intersect_key($form_state['values'], array_combine($object_keys, $object_keys));
   if (empty($object['title_field'])) {
     $object['title_field'] = NULL;
@@ -144,12 +151,12 @@ function xml_form_builder_associations_form_submit(array $form, array &$form_sta
   }
   try {
     db_insert('xml_form_builder_form_associations')
-        ->fields($object)
-        ->execute();
+      ->fields($object)
+      ->execute();
     drupal_set_message(t('Successfully added association.'));
   }
   catch (Exception $e) {
-    drupal_set_message(t('Failed to add association.'), 'error');
+    drupal_set_message(t('Failed to add association, with error: @msg', array('@msg' => $e->getMessage())), 'error');
   }
 }
 


### PR DESCRIPTION
**ISLANDORA-2105**: (https://jira.duraspace.org/browse/ISLANDORA-2105)

# What does this Pull Request do?

Fixes an issue with XML Forms to CMODEL association when the default XSLT option is enabled. Two fields, self-transform, and to DC transform are not rendered/hidden which leads to being absent on form submit from $form_state. Those values are required when saving the settings in DB making that operation fail.

# What's new?
The simplest of the fixes to the described issue. In case default XSLT is selected, the missing values, transform and self-transform that can not be set via the FORM are given default values. Those values could be later overridden, via the edit association functionality, if needed.

# How should this be tested?

Before applying the diff, on your islandora VM
1.- Go to admin/islandora/xmlform/settings and enable "use default DC XSLT"
2.- Go to admin/islandora/xmlform, and press associate on any existing XML Form in the list.
3.- try to fill all the fields (you can skip the template) and "add Association", you should see a message in red that says:
"Failed to add association"

Apply the diff, do the same," Add Association" should work as expected.

# Additional Notes:

There are actually many ways of solving this issue, including the use of the + operator on adding Arrays (a default one v/s the form_state) but my tests showed this one to be faster. Also, this whole form lacks validation and there is a certain inconsistency on actually hidding those fields v/s documenting that if the default transformation is in place the settings won't take effect. I would actually prefer not to hide them at all.

There could be DCS issues, the ones I run are much newer than Travis ones, so probably will have to adjust. 😢 

# Interested parties
@jordandukart @rosiel @kimpham54  @Islandora/7-x-1-x-committers