### PR TITLE
ISLANDORA-2140: Prevent garbled MODS when going back and forth in ingest forms

### DIFF
--- a/api/Create.inc
+++ b/api/Create.inc
@@ -7,6 +7,7 @@
 
 module_load_include('inc', 'xml_form_api', 'ActionInterface');
 module_load_include('inc', 'xml_form_api', 'Path');
+module_load_include('inc', 'xml_form_api', 'XMLFormPrePopulator');
 module_load_include('inc', 'xml_schema_api', 'InsertOrderMap');
 
 /**
@@ -166,7 +167,35 @@ class Create implements ActionInterface {
       $parent = $results->item(0);
       $created = $this->doCreate($document, $value);
       $this->append($document, $created, $parent);
-      $document->registry->register($element->hash, $created);
+      // If we added a whole XML fragment, we re-read the correct node to register.
+      if ($this->type == self::XML && isset($element->actions) && isset($element->actions->read)) {
+          $read_nodes = dom_node_list_to_array($element->actions->read->execute($document, $element));
+          // Find the first node for which $created is a parent (or self).
+          foreach ($read_nodes as $read_node) {
+              $node = $read_node;
+              do {
+                  if ($node === $created) {
+                      break;
+                  }
+              }
+              while ($node = $node->parentNode);
+              if ($node) {
+                  $created_toregister = $read_node;
+                  break;
+              }
+          }
+      }
+      if (!isset($created_toregister)) {
+          $created_toregister = $created;
+      }
+      $document->registry->register($element->hash, $created_toregister);
+      // If we added a whole XML fragment, we update the FormElement's value.
+      if ($this->type == self::XML) {
+          $populator = new XMLFormPrePopulator($document);
+          $populator->prePopulateElement($element);
+          unset($populator);
+          $element->value = $element->default_value;
+      }
       return TRUE;
     }
     return FALSE;

--- a/api/Create.inc
+++ b/api/Create.inc
@@ -178,8 +178,7 @@ class Create implements ActionInterface {
             if ($node === $created) {
               break;
             }
-          }
-          while ($node = $node->parentNode);
+          } while ($node = $node->parentNode);
           if ($node) {
             $created_toregister = $read_node;
             break;

--- a/api/Create.inc
+++ b/api/Create.inc
@@ -167,34 +167,35 @@ class Create implements ActionInterface {
       $parent = $results->item(0);
       $created = $this->doCreate($document, $value);
       $this->append($document, $created, $parent);
-      // If we added a whole XML fragment, we re-read the correct node to register.
+      // If we added a whole XML fragment, we re-read the correct node to
+      // register.
       if ($this->type == self::XML && isset($element->actions) && isset($element->actions->read)) {
-          $read_nodes = dom_node_list_to_array($element->actions->read->execute($document, $element));
-          // Find the first node for which $created is a parent (or self).
-          foreach ($read_nodes as $read_node) {
-              $node = $read_node;
-              do {
-                  if ($node === $created) {
-                      break;
-                  }
-              }
-              while ($node = $node->parentNode);
-              if ($node) {
-                  $created_toregister = $read_node;
-                  break;
-              }
+        $read_nodes = dom_node_list_to_array($element->actions->read->execute($document, $element));
+        // Find the first node for which $created is a parent (or self).
+        foreach ($read_nodes as $read_node) {
+          $node = $read_node;
+          do {
+            if ($node === $created) {
+              break;
+            }
           }
+          while ($node = $node->parentNode);
+          if ($node) {
+            $created_toregister = $read_node;
+            break;
+          }
+        }
       }
       if (!isset($created_toregister)) {
-          $created_toregister = $created;
+        $created_toregister = $created;
       }
       $document->registry->register($element->hash, $created_toregister);
       // If we added a whole XML fragment, we update the FormElement's value.
       if ($this->type == self::XML) {
-          $populator = new XMLFormPrePopulator($document);
-          $populator->prePopulateElement($element);
-          unset($populator);
-          $element->value = $element->default_value;
+        $populator = new XMLFormPrePopulator($document);
+        $populator->prePopulateElement($element);
+        unset($populator);
+        $element->value = $element->default_value;
       }
       return TRUE;
     }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2140

# What does this Pull Request do?

Address [ISLANDORA-2140](https://jira.duraspace.org/browse/ISLANDORA-2140), i.e. prevent garbled MODS when going back and forth in ingest forms.

In multi-paged ingest forms, when the user returns to the metadata form and re-submits, the original code swallows certain XML sub-elements inside the resulting MODS. More precisely, whenever an XML fragment of the form `<element><sub-element>%value%</sub-element></element>` is created, going back to and re-submitting the metadata form results in a MODS containing only `<element>the inserted value</element>`. This breaks the MODS standard, along with subsequent logic such as CSL-driven metadata views.

The proposed solution fixes this behaviour.

# What's new?

When creating an XML fragment:
* adjust the DOMNode to register in the [NodeRegistry](https://github.com/Islandora/islandora_xml_forms/blob/7.x/api/NodeRegistry.inc) of the handled [XMLDocument](https://github.com/Islandora/islandora_xml_forms/blob/7.x/api/XMLDocument.inc)
* update the FormElement's value with the [Read](https://github.com/Islandora/islandora_xml_forms/blob/7.x/api/Read.inc)-value of the DOMNode just created inside the DOMDocument

If, during ingest, the user goes back to the metadata form, those adjustments allow the [Update action](https://github.com/Islandora/islandora_xml_forms/blob/7.x/api/Update.inc) triggered upon re-submission to work correctly.

# How should this be tested?

* Convince yourself of the issue by following the ten steps described in the [JIRA ticket](https://jira.duraspace.org/browse/ISLANDORA-2140)
* Apply the diff and assess that the problem has disappeared
* Test other ingest forms (content models)

Of course, do not test directly on a production environment!

_Note_: The modifications change the [NodeRegistry](https://github.com/Islandora/islandora_xml_forms/blob/7.x/api/NodeRegistry.inc) built during DOMNode creation ([Create action](https://github.com/Islandora/islandora_xml_forms/blob/7.x/api/Create.inc)) in a substantial manner. Therefore, **regression testing** might be advisable.

# Additional Notes:
* Does this change require documentation to be updated? **no**
* Does this change add any new dependencies? **no**
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? **no**
* Could this change impact execution of existing code? **possibly**

# Interested parties
@DiegoPino, @Islandora/7-x-1-x-committers
