### PR TITLE
ISLANDORA-2115: Add breadcrumbs

### DIFF
--- a/builder/Edit.inc
+++ b/builder/Edit.inc
@@ -24,6 +24,9 @@ function xml_form_builder_edit($form_name) {
     drupal_not_found();
     exit();
   }
+  $breadcrumb[] = l('Home', '<front>');
+  $breadcrumb[] = l('Form Builder', 'admin/islandora/xmlform');
+  drupal_set_breadcrumb($breadcrumb);
 
   xml_form_builder_edit_include_css();
   xml_form_builder_edit_include_js();

--- a/builder/Edit.inc
+++ b/builder/Edit.inc
@@ -24,8 +24,8 @@ function xml_form_builder_edit($form_name) {
     drupal_not_found();
     exit();
   }
-  $breadcrumb[] = l('Home', '<front>');
-  $breadcrumb[] = l('Form Builder', 'admin/islandora/xmlform');
+  $breadcrumb[] = l(t('Home'), '<front>');
+  $breadcrumb[] = l(t('Form Builder'), 'admin/islandora/xmlform');
   drupal_set_breadcrumb($breadcrumb);
 
   xml_form_builder_edit_include_css();

--- a/builder/Edit.inc
+++ b/builder/Edit.inc
@@ -25,6 +25,7 @@ function xml_form_builder_edit($form_name) {
     exit();
   }
   $breadcrumb[] = l(t('Home'), '<front>');
+  $breadcrumb[] = l(t('Islandora Admin'), 'admin/islandora');
   $breadcrumb[] = l(t('Form Builder'), 'admin/islandora/xmlform');
   drupal_set_breadcrumb($breadcrumb);
 

--- a/builder/Main.inc
+++ b/builder/Main.inc
@@ -17,7 +17,6 @@ function xml_form_builder_main() {
 
   module_load_include('inc', 'xml_form_builder', 'XMLFormRepository');
   $names = XMLFormRepository::GetNames();
-
   // No forms exist can only create.
   if (count($names) == 0) {
     return '<div>No forms are defined. Please create a new form.</div><br/>';

--- a/builder/Preview.inc
+++ b/builder/Preview.inc
@@ -24,8 +24,8 @@
 function xml_form_builder_preview(array $form, array &$form_state, $form_name) {
   form_load_include($form_state, 'inc', 'xml_form_builder', 'Preview');
   $form = xml_form_builder_get_form($form, $form_state, $form_name);
-  $breadcrumb[] = l('Home', '<front>');
-  $breadcrumb[] = l('Form Builder', 'admin/islandora/xmlform');
+  $breadcrumb[] = l(t('Home'), '<front>');
+  $breadcrumb[] = l(t('Form Builder'), 'admin/islandora/xmlform');
   drupal_set_breadcrumb($breadcrumb);
   $form['submit'] = array(
     '#type' => 'submit',

--- a/builder/Preview.inc
+++ b/builder/Preview.inc
@@ -25,6 +25,7 @@ function xml_form_builder_preview(array $form, array &$form_state, $form_name) {
   form_load_include($form_state, 'inc', 'xml_form_builder', 'Preview');
   $form = xml_form_builder_get_form($form, $form_state, $form_name);
   $breadcrumb[] = l(t('Home'), '<front>');
+  $breadcrumb[] = l(t('Islandora Admin'), 'admin/islandora');
   $breadcrumb[] = l(t('Form Builder'), 'admin/islandora/xmlform');
   drupal_set_breadcrumb($breadcrumb);
   $form['submit'] = array(

--- a/builder/Preview.inc
+++ b/builder/Preview.inc
@@ -24,6 +24,9 @@
 function xml_form_builder_preview(array $form, array &$form_state, $form_name) {
   form_load_include($form_state, 'inc', 'xml_form_builder', 'Preview');
   $form = xml_form_builder_get_form($form, $form_state, $form_name);
+  $breadcrumb[] = l('Home', '<front>');
+  $breadcrumb[] = l('Form Builder', 'admin/islandora/xmlform');
+  drupal_set_breadcrumb($breadcrumb);
   $form['submit'] = array(
     '#type' => 'submit',
     '#value' => 'Submit',


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2115)

# What does this Pull Request do?

Adds breadcrumbs to the Edit and Preview pages in Form Builder. 

# What's new?
Originally, breadcrumbs just point to Home (<front>), making it annoying to navigate from previews and editing back to the Form Builder. This PR adds Form Builder to the breadcrumb list.

# How should this be tested?

Go to Form Builder. View a form, Edit a form. Verify that breadcrumbs exist and go to the right places.

# Interested parties
@Islandora/7-x-1-x-committers
