### PR TITLE
Make Creative Commons license optional

### DIFF
--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -97,9 +97,15 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     $form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'] = $license_output_id;
   }
 
+  // Disable Creative commons by default.
+  $disabled = TRUE;
   // Figure out license state.
   if (!isset($form_state['input'][$element['#name']]) && isset($element['#default_value'])) {
     // Reversing this array facilitates value_callback mangling by community.
+    if (!empty($element['#default_value'])) {
+      // There is a value defined so it wasn't disabled.
+      $disabled = FALSE;
+    }
     $default_value_array = array_reverse(explode('/', $element['#default_value']));
     $properties = explode('-', array_pop($default_value_array));
 
@@ -131,6 +137,11 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     $derivatives = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_modifications']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_modifications'] : 'y';
     $commercial = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_commercial']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_commercial'] : 'y';
     $jurisdiction = isset($form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction']) ? $form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction'] : 'ca';
+    if (!isset($form_state['input'][$element['#name']]['license_fieldset']['disabled']) &&
+      isset($form_state['input'][$element['#name']]['license_fieldset'])) {
+      // If the disabled element is missing but the license fieldset exists.
+      $disabled = FALSE;
+    }
   }
 
   // Form elements.
@@ -139,6 +150,13 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     '#collapsed' => FALSE,
     '#collapsible' => TRUE,
     '#title' => t('License'),
+  );
+
+  $element['license_fieldset']['disabled'] = array(
+    '#type' => 'checkbox',
+    '#title' => t("Don't output Creative Commons license."),
+    '#description' => t('Check this box to avoid outputting a creative commons license. This will still output a blank element, so make sure to use a cleanup template to remote it.'),
+    '#default_value' => $disabled,
   );
 
   $element['license_fieldset']['allow_modifications'] = array(
@@ -173,6 +191,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
       'callback' => 'xml_form_elements_creative_commons_ajax',
     ),
   );
+
   // Value gets populated if default value is populated.
   if (current_path() == 'system/ajax' || !$element['#value'] ||
     (isset($element['#default_value']) && $element['#value'] == $element['#default_value'])) {
@@ -183,7 +202,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     $element['#tree'] = FALSE;
   }
 
-  $response = xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction);
+  $response = xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction, $disabled);
   if ($response) {
     $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = (string) $response->{'license-uri'};
     $element['license_fieldset']['license_output'] = array(
@@ -193,7 +212,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     );
   }
   else {
-    $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction);
+    $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction, $disabled);
     $element['license_fieldset']['license_output'] = array();
   }
 
@@ -227,21 +246,27 @@ function xml_form_elements_creative_commons_ajax(&$form, &$form_state) {
  *   SimpleXMLElement the return from the REST API.
  *   FALSE if failed request.
  */
-function xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction) {
-  $response = drupal_http_request(url(
-    'http://api.creativecommons.org/rest/1.5/license/standard/get',
-    array(
-      'query' => array(
-        'commercial' => $commercial,
-        'derivatives' => $derivatives,
-        'jurisdiction' => $jurisdiction,
-      ),
-    )
-  ));
-  if ($response->code != 200) {
+function xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction, $disabled = FALSE) {
+  if ($disabled) {
     return FALSE;
   }
-  return simplexml_load_string($response->data, 'SimpleXMLElement');
+  else {
+    $response = drupal_http_request(url(
+      'http://api.creativecommons.org/rest/1.5/license/standard/get',
+      array(
+        'query' => array(
+          'commercial' => $commercial,
+          'derivatives' => $derivatives,
+          'jurisdiction' => $jurisdiction,
+        ),
+      )
+    ));
+    if ($response->code != 200) {
+      error_log("xml_form responded {$response->code}");
+      return FALSE;
+    }
+    return simplexml_load_string($response->data, 'SimpleXMLElement');
+  }
 }
 
 /**
@@ -257,16 +282,21 @@ function xml_form_elements_get_creative_commons($commercial, $derivatives, $juri
  * @return string
  *   The value of the element.
  */
-function xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction) {
-  $arguments = '';
-  if ($commercial == 'n') {
-    $arguments = "$arguments-nc";
+function xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction, $disabled = FALSE) {
+  if ($disabled) {
+    return '';
   }
-  if ($derivatives == 'n') {
-    $arguments = "$arguments-nd";
+  else {
+    $arguments = '';
+    if ($commercial == 'n') {
+      $arguments = "$arguments-nc";
+    }
+    if ($derivatives == 'n') {
+      $arguments = "$arguments-nd";
+    }
+    elseif ($derivatives == 'sa') {
+      $arguments = "$arguments-sa";
+    }
+    return "http://creativecommons.org/licenses/by$arguments/2.5/$jurisdiction/";
   }
-  elseif ($derivatives == 'sa') {
-    $arguments = "$arguments-sa";
-  }
-  return "http://creativecommons.org/licenses/by$arguments/2.5/$jurisdiction/";
 }

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -15,6 +15,8 @@
  *   The element definition.
  */
 function xml_form_elements_creative_commons($element, &$form_state) {
+  $creative_commons_base_url = "http://creativecommons.org/licenses/";
+
   $modification_options = array(
     'y' => t('Yes'),
     'n' => t('No'),
@@ -106,7 +108,9 @@ function xml_form_elements_creative_commons($element, &$form_state) {
       // There is a value defined so it wasn't disabled.
       $disabled = FALSE;
     }
-    $default_value_array = array_reverse(explode('/', $element['#default_value']));
+    $default_value_array = array_reverse(explode('/',
+      str_replace($creative_commons_base_url, "", $element['#default_value'])
+    ));
     $properties = explode('-', array_pop($default_value_array));
 
     $commercial = 'y';
@@ -193,7 +197,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   );
 
   // Value gets populated if default value is populated.
-  if (current_path() == 'system/ajax' || !$element['#value'] ||
+  if (current_path() == 'system/ajax' || (!$element['#value'] && !$disabled) ||
     (isset($element['#default_value']) && $element['#value'] == $element['#default_value'])) {
     $element['#tree'] = TRUE;
   }

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -635,7 +635,10 @@ function xml_form_elements_creative_commons_value_callback(&$element, $input, &$
     }
     else {
       extract($input['license_fieldset']);
-      return xml_form_elements_creative_commons_value($allow_commercial, $allow_modifications, $license_jurisdiction);
+      if (!isset($disabled)) {
+        $disabled = FALSE;
+      }
+      return xml_form_elements_creative_commons_value($allow_commercial, $allow_modifications, $license_jurisdiction, $disabled);
     }
   }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2173

Related work: https://github.com/Islandora/islandora_xml_forms/pull/249

# What does this Pull Request do?

Adds a checkbox which alters the output to nothing, this leaves an empty element that can be removed by a clean up stylesheet.

It also removes the `http://creativecommons.org/licenses/` from the front of the license before trying to use it. This seems to be required to parse the existing CC license back into the form.

# How should this be tested?

Pull down PR
Load item with CC license, the license select boxes should correctly reset.
Alter the checkboxes, Update.
Check that the MODS is correctly updated.
Re-load the item and ensure the select boxes are still correctly set.
Check the disable checkbox. Update
Check the MODS that the license element is empty.
Re-load the item, un-check the checkbox and choose the license. Update.
Check the MODS for the correct license.

# Additional Notes:

Example:
* Does this change require documentation to be updated? Maybe, checkbox is pretty self-explanatory.
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@DiegoPino @bryjbrown @bondjimbond @Islandora/7-x-1-x-committers
