### PR TITLE
Set #tree == TRUE if no #value and no $form_state['disabled'] set.

### DIFF
--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -112,7 +112,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
 
     // Reversing this array facilitates value_callback mangling by community.
     $default_value_array = array_reverse(explode('/',
-      str_replace($creative_commons_base_url,"", $element['#default_value'])
+      str_replace($creative_commons_base_url, "", $element['#default_value'])
     ));
     $properties = explode('-', array_pop($default_value_array));
 

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -159,7 +159,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   $element['license_fieldset']['disabled'] = array(
     '#type' => 'checkbox',
     '#title' => t("Don't output Creative Commons license."),
-    '#description' => t('Check this box to avoid outputting a creative commons license. This will still output a blank element, so make sure to use a cleanup template to remote it.'),
+    '#description' => t('Check this box to avoid outputting a creative commons license. This will still output a blank element, so make sure to use a cleanup template to remove it.'),
     '#default_value' => $disabled,
   );
 

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -172,6 +172,11 @@ function xml_form_elements_creative_commons($element, &$form_state) {
       'wrapper' => $license_output_id,
       'callback' => 'xml_form_elements_creative_commons_ajax',
     ),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="accessCondition[license_fieldset][disabled]"]' => array('checked' => FALSE),
+      ),
+    ),
   );
 
   $element['license_fieldset']['allow_commercial'] = array(
@@ -182,6 +187,11 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     '#ajax' => array(
       'wrapper' => $license_output_id,
       'callback' => 'xml_form_elements_creative_commons_ajax',
+    ),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="accessCondition[license_fieldset][disabled]"]' => array('checked' => FALSE),
+      ),
     ),
   );
 
@@ -194,10 +204,15 @@ function xml_form_elements_creative_commons($element, &$form_state) {
       'wrapper' => $license_output_id,
       'callback' => 'xml_form_elements_creative_commons_ajax',
     ),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="accessCondition[license_fieldset][disabled]"]' => array('checked' => FALSE),
+      ),
+    ),
   );
 
   // Value gets populated if default value is populated.
-  if (current_path() == 'system/ajax' || (!$element['#value'] && !$disabled) ||
+  if (current_path() == 'system/ajax' || (!$element['#value'] && !isset($form_state['input'][$element['#name']]['license_fieldset']['disabled'])) ||
     (isset($element['#default_value']) && $element['#value'] == $element['#default_value'])) {
     $element['#tree'] = TRUE;
   }
@@ -213,6 +228,11 @@ function xml_form_elements_creative_commons($element, &$form_state) {
       '#type' => 'item',
       '#id' => $license_output_id,
       '#markup' => '<strong>' . t('Selected license:') . '</strong><div>' . $response->html->asXml() . '</div>',
+      '#states' => array(
+        'visible' => array(
+          ':input[name="accessCondition[license_fieldset][disabled]"]' => array('checked' => FALSE),
+        ),
+      ),
     );
   }
   else {

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -85,6 +85,8 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     'vn' => t('Vietnam'),
   );
 
+  $default_jurisdiction = 'international';
+
   $commercial_options = array(
     'y' => t('Yes'),
     'n' => t('No'),
@@ -103,13 +105,14 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   $disabled = TRUE;
   // Figure out license state.
   if (!isset($form_state['input'][$element['#name']]) && isset($element['#default_value'])) {
-    // Reversing this array facilitates value_callback mangling by community.
+    // If there is a value defined then it wasn't disabled.
     if (!empty($element['#default_value'])) {
-      // There is a value defined so it wasn't disabled.
       $disabled = FALSE;
     }
+
+    // Reversing this array facilitates value_callback mangling by community.
     $default_value_array = array_reverse(explode('/',
-      str_replace($creative_commons_base_url, "", $element['#default_value'])
+      str_replace($creative_commons_base_url,"", $element['#default_value'])
     ));
     $properties = explode('-', array_pop($default_value_array));
 
@@ -135,12 +138,13 @@ function xml_form_elements_creative_commons($element, &$form_state) {
       }
     }
 
-    $jurisdiction = empty($default_value_array[1]) ? 'international' : $default_value_array[1];
+    $jurisdiction = empty($default_value_array[1]) ? $default_jurisdiction : $default_value_array[1];
+
   }
   else {
     $derivatives = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_modifications']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_modifications'] : 'y';
     $commercial = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_commercial']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_commercial'] : 'y';
-    $jurisdiction = isset($form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction']) ? $form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction'] : 'ca';
+    $jurisdiction = isset($form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction']) ? $form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction'] : $default_jurisdiction;
     if (!isset($form_state['input'][$element['#name']]['license_fieldset']['disabled']) &&
       isset($form_state['input'][$element['#name']]['license_fieldset'])) {
       // If the disabled element is missing but the license fieldset exists.
@@ -174,7 +178,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     ),
     '#states' => array(
       'visible' => array(
-        ':input[name="accessCondition[license_fieldset][disabled]"]' => array('checked' => FALSE),
+        ":input[name=\"{$element['#name']}[license_fieldset][disabled]\"]" => array('checked' => FALSE),
       ),
     ),
   );
@@ -190,7 +194,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     ),
     '#states' => array(
       'visible' => array(
-        ':input[name="accessCondition[license_fieldset][disabled]"]' => array('checked' => FALSE),
+        ":input[name=\"{$element['#name']}[license_fieldset][disabled]\"]" => array('checked' => FALSE),
       ),
     ),
   );
@@ -206,7 +210,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     ),
     '#states' => array(
       'visible' => array(
-        ':input[name="accessCondition[license_fieldset][disabled]"]' => array('checked' => FALSE),
+        ":input[name=\"{$element['#name']}[license_fieldset][disabled]\"]" => array('checked' => FALSE),
       ),
     ),
   );
@@ -230,7 +234,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
       '#markup' => '<strong>' . t('Selected license:') . '</strong><div>' . $response->html->asXml() . '</div>',
       '#states' => array(
         'visible' => array(
-          ':input[name="accessCondition[license_fieldset][disabled]"]' => array('checked' => FALSE),
+          ":input[name=\"{$element['#name']}[license_fieldset][disabled]\"]" => array('checked' => FALSE),
         ),
       ),
     );
@@ -311,6 +315,7 @@ function xml_form_elements_creative_commons_value($commercial, $derivatives, $ju
     return '';
   }
   else {
+    $license_version = '2.5';
     $arguments = '';
     if ($commercial == 'n') {
       $arguments = "$arguments-nc";
@@ -321,6 +326,15 @@ function xml_form_elements_creative_commons_value($commercial, $derivatives, $ju
     elseif ($derivatives == 'sa') {
       $arguments = "$arguments-sa";
     }
-    return "http://creativecommons.org/licenses/by$arguments/2.5/$jurisdiction/";
+    if ($jurisdiction == 'international') {
+      $license_version = '4.0';
+      // Not needed for international.
+      $jurisdiction = '';
+    }
+    else {
+      // If not international add the trailing slash.
+      $jurisdiction .= '/';
+    }
+    return "http://creativecommons.org/licenses/by$arguments/$license_version/$jurisdiction";
   }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2192

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

https://groups.google.com/d/msgid/islandora/374915f1-d235-40c0-8ce3-3186f1924b27%40googlegroups.com?utm_medium=email&utm_source=footer

Problem in 3 points:
1. XML Form Builder is not meant to expect with empty elements.
1. Creative Commons has this AJAX callback which needs `#tree = TRUE`.
1. XML Form Builder needs flat elements to when output meaning `#tree = FALSE`

So we need `#tree = TRUE` for any number of AJAX requests, but then switch to `#tree = FALSE` when we are outputting for the last time.

This seems to work correctly now except that if you start with a disabled CC element then the AJAX requests don't give you that pretty license HTML. 😢 

But those Ajax requests are slow and painful to wait for and if you don't your license could be persisted differently than the form appears. Someone else can fix it.

# What does this Pull Request do?

Alters the `#tree` question to say if the `#value` is blank (which can mean "") but the $form_state has a disabled value set, then we want `#tree = FALSE` and output nothing for this element.

It also hide the CC fields when the disabled checkbox is checked to make it cleaner.

# How should this be tested?

Make Creative commons licenses, alter the objects in any way you can think of and verify your changes are persisted.

I tried starting with a new object setting a license, saving, editing the license, saving, disabling the license, saving, editing without re-enabling the license, saving, re-enabling the license, saving.

I also tried the above with a new object without a license to start.

But please, please, please really test this.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@bondjimbond @DiegoPino 
