### PR TITLE
ISLANDORA-2205: Re-design `creative_commons` element

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Having problems or solved a problem? Check out the Islandora google groups for a
 * [Islandora Dev Group](https://groups.google.com/forum/?hl=en&fromgroups#!forum/islandora-dev)
 * Note if you get error "XML form definition is not valid." during ingest you need to update your libxml2 version to 2.7+
 
+### Known Issues
+
+* **Creative Commons Form Element**: Note that there seems to be a bug in the Creative Commons API triggered by certain combinations of _License Jurisdiction_ and other parameters. Querying, e.g., "Yes, as long as others share alike" for _Allow modifications of your work?_ and "Finland" for _License Jurisdiction_ results in a CC-BY-SA, resp. CC-BY-NC-SA, _4.0 International_ license, instead of the corresponding _1.0 Finland_ version (which exists and is not deprecated). The only way to obtain the correct license in this case is to enter `http://creativecommons.org/licenses/by-sa/1.0/fi/`, resp. `http://creativecommons.org/licenses/by-nc-sa/1.0/fi/`, _manually_ (choose "Manually select a license URI" for _Select a license type_). Also, this kind of licenses cannot be set by administrators in Form Builder as _Default Value_ for the Creative Commons Form Element.
+
 ## FAQ
 
 Q. Can I convert an existing field to any form element type listed in the "Type" options under the "Common Form Controls" tab (or create new form elements using any form element type)?

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -2,11 +2,19 @@
 
 /**
  * @file
- * Code for creative commons form elements.
+ * Code for `creative_commons` form elements.
  */
 
 /**
- * Creates a creative_commons form element.
+ * Constants
+ */
+const XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL = 'http://creativecommons.org/';
+const XML_FORM_ELEMENTS_CREATIVE_COMMONS_API_URL = 'https://api.creativecommons.org/rest/1.5/';
+const XML_FORM_ELEMENTS_CREATIVE_COMMONS_LICENSE_URI_DEFAULT = 'http://creativecommons.org/licenses/by/4.0/';
+const XML_FORM_ELEMENTS_CREATIVE_COMMONS_DISABLED_DEFAULT = TRUE;
+
+/**
+ * Creates a `creative_commons` form element.
  *
  * @param array $form_state
  *   The form state.
@@ -15,7 +23,13 @@
  *   The element definition.
  */
 function xml_form_elements_creative_commons($element, &$form_state) {
-  $creative_commons_base_url = "http://creativecommons.org/licenses/";
+  $license_options = array(
+    'none' => t('Do not output any license'),
+    'by' => t('Creative Commons Attribution'),
+    'zero' => t('CC0 Universal (Public Domain)'),
+    'mark' => t('Public Domain Mark'),
+    'manual' => t('Manually enter a license URI'),
+  );
 
   $modification_options = array(
     'y' => t('Yes'),
@@ -23,6 +37,13 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     'sa' => t('Yes, as long as others share alike'),
   );
 
+  $commercial_options = array(
+    'y' => t('Yes'),
+    'n' => t('No'),
+  );
+
+  // List retrieved on 2018-04-28 from
+  // https://api.creativecommons.org/rest/1.5/support/jurisdictions
   $countries = array(
     'international' => t('International'),
     'ar' => t('Argentina'),
@@ -47,13 +68,15 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     'de' => t('Germany'),
     'gr' => t('Greece'),
     'gt' => t('Guatemala'),
-    'hk' => t('Hong kong'),
+    'hk' => t('Hong Kong'),
     'hu' => t('Hungary'),
+    'igo' => t('IGO'),
     'in' => t('India'),
     'ie' => t('Ireland'),
     'il' => t('Israel'),
     'it' => t('Italy'),
     'jp' => t('Japan'),
+    'kr' => t('Korea'),
     'lu' => t('Luxembourg'),
     'mk' => t('Macedonia'),
     'my' => t('Malaysia'),
@@ -72,113 +95,68 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     'sg' => t('Singapore'),
     'si' => t('Slovenia'),
     'za' => t('South Africa'),
-    'kr' => t('South Korea'),
     'es' => t('Spain'),
     'se' => t('Sweden'),
     'ch' => t('Switzerland'),
     'tw' => t('Taiwan'),
     'th' => t('Thailand'),
-    'uk' => t('UK: England & Wales'),
-    'scotland' => t('Uk: Scotland'),
     'ug' => t('Uganda'),
-    'us' => t('United states'),
+    'uk' => t('UK: England & Wales'),
+    'scotland' => t('UK: Scotland'),
+    'us' => t('United States'),
+    've' => t('Venezuela'),
     'vn' => t('Vietnam'),
   );
 
-  $default_jurisdiction = 'international';
-
-  $commercial_options = array(
-    'y' => t('Yes'),
-    'n' => t('No'),
-  );
-
   // Get an ID for ajax.
-  if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'])) {
-    $license_output_id = $form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'];
+  if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['license_fieldset_id'])) {
+    $license_fieldset_id = $form_state['storage']['xml_form_elements'][$element['#name']]['license_fieldset_id'];
   }
   else {
-    $license_output_id = drupal_html_id('license_output');
-    $form_state['storage']['xml_form_elements'][$element['#name']]['license_output_id'] = $license_output_id;
+    $license_fieldset_id = drupal_html_id('license_fieldset');
+    $form_state['storage']['xml_form_elements'][$element['#name']]['license_fieldset_id'] = $license_fieldset_id;
   }
 
-  // Disable Creative commons by default.
-  $disabled = TRUE;
-  // Figure out license state.
-  if (!isset($form_state['input'][$element['#name']]) && isset($element['#default_value'])) {
-    // If there is a value defined then it wasn't disabled.
-    if (!empty($element['#default_value'])) {
-      $disabled = FALSE;
-    }
-
-    // Reversing this array facilitates value_callback mangling by community.
-    $default_value_array = array_reverse(explode('/',
-      str_replace($creative_commons_base_url, "", $element['#default_value'])
-    ));
-    $properties = explode('-', array_pop($default_value_array));
-
-    $commercial = 'y';
-    $derivatives = 'y';
-
-    foreach ($properties as $property) {
-      switch ($property) {
-        case 'by':
-          break;
-
-        case 'nc':
-          $commercial = 'n';
-          break;
-
-        case 'nd':
-          $derivatives = 'n';
-          break;
-
-        case 'sa':
-          $derivatives = 'sa';
-          break;
-      }
-    }
-
-    $jurisdiction = empty($default_value_array[1]) ? $default_jurisdiction : $default_value_array[1];
-
-  }
-  else {
-    $derivatives = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_modifications']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_modifications'] : 'y';
-    $commercial = isset($form_state['input'][$element['#name']]['license_fieldset']['allow_commercial']) ? $form_state['input'][$element['#name']]['license_fieldset']['allow_commercial'] : 'y';
-    $jurisdiction = isset($form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction']) ? $form_state['input'][$element['#name']]['license_fieldset']['license_jurisdiction'] : $default_jurisdiction;
-    if (!isset($form_state['input'][$element['#name']]['license_fieldset']['disabled']) &&
-      isset($form_state['input'][$element['#name']]['license_fieldset'])) {
-      // If the disabled element is missing but the license fieldset exists.
-      $disabled = FALSE;
-    }
-  }
+  // Get current values and store them in the element.
+  $input = isset($form_state['input'][$element['#name']]) ? $form_state['input'][$element['#name']] : NULL;
+  $values = xml_form_elements_creative_commons_get_value_array_from_input($element, $input, $form_state);
+  $element['#value'] = $values;
 
   // Form elements.
+
   $element['license_fieldset'] = array(
+    '#id' => $license_fieldset_id,
     '#type' => 'fieldset',
     '#collapsed' => FALSE,
     '#collapsible' => TRUE,
     '#title' => t('License'),
   );
 
-  $element['license_fieldset']['disabled'] = array(
-    '#type' => 'checkbox',
-    '#title' => t("Don't output Creative Commons license."),
-    '#description' => t('Check this box to avoid outputting a creative commons license. This will still output a blank element, so make sure to use a cleanup template to remove it.'),
-    '#default_value' => $disabled,
+  $element['license_fieldset']['license_type'] = array(
+    '#type' => 'select',
+    '#title' => t('Select a license type'),
+    '#description' => t('Select "@option" to avoid outputting a creative commons license. This will still output a blank element in the resulting XML, so make sure to use a cleanup template to remove it.', array('@option' => $license_options['none'])),
+    '#options' => $license_options,
+    '#default_value' => $values['license_fieldset']['license_type'],
+    '#ajax' => array(
+      'wrapper' => $license_fieldset_id,
+      'callback' => 'xml_form_elements_creative_commons_ajax',
+    ),
   );
 
   $element['license_fieldset']['allow_modifications'] = array(
     '#type' => 'select',
     '#title' => t('Allow modifications of your work?'),
+    '#description' => t('Note that this is only relevant if you selected "@option" above.', array('@option' => $license_options['by'])),
     '#options' => $modification_options,
-    '#default_value' => $derivatives,
+    '#default_value' => $values['license_fieldset']['allow_modifications'],
     '#ajax' => array(
-      'wrapper' => $license_output_id,
+      'wrapper' => $license_fieldset_id,
       'callback' => 'xml_form_elements_creative_commons_ajax',
     ),
     '#states' => array(
-      'visible' => array(
-        ":input[name=\"{$element['#name']}[license_fieldset][disabled]\"]" => array('checked' => FALSE),
+      'invisible' => array(
+        ":input[name=\"{$element['#name']}[license_fieldset][license_type]\"]" => array('!value' => 'by'),
       ),
     ),
   );
@@ -186,15 +164,16 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   $element['license_fieldset']['allow_commercial'] = array(
     '#type' => 'select',
     '#title' => t('Allow commercial uses of your work?'),
+    '#description' => t('Note that this is only relevant if you selected "@option" above.', array('@option' => $license_options['by'])),
     '#options' => $commercial_options,
-    '#default_value' => $commercial,
+    '#default_value' => $values['license_fieldset']['allow_commercial'],
     '#ajax' => array(
-      'wrapper' => $license_output_id,
+      'wrapper' => $license_fieldset_id,
       'callback' => 'xml_form_elements_creative_commons_ajax',
     ),
     '#states' => array(
-      'visible' => array(
-        ":input[name=\"{$element['#name']}[license_fieldset][disabled]\"]" => array('checked' => FALSE),
+      'invisible' => array(
+        ":input[name=\"{$element['#name']}[license_fieldset][license_type]\"]" => array('!value' => 'by'),
       ),
     ),
   );
@@ -203,59 +182,505 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     '#type' => 'select',
     '#title' => t('License Jurisdiction'),
     '#options' => $countries,
-    '#default_value' => $jurisdiction,
+    '#description' => t('Note that this is only relevant if you selected "@option" above.', array('@option' => $license_options['by'])),
+    '#default_value' => $values['license_fieldset']['license_jurisdiction'],
     '#ajax' => array(
-      'wrapper' => $license_output_id,
+      'wrapper' => $license_fieldset_id,
       'callback' => 'xml_form_elements_creative_commons_ajax',
     ),
     '#states' => array(
-      'visible' => array(
-        ":input[name=\"{$element['#name']}[license_fieldset][disabled]\"]" => array('checked' => FALSE),
+      'invisible' => array(
+        ":input[name=\"{$element['#name']}[license_fieldset][license_type]\"]" => array('!value' => 'by'),
       ),
     ),
   );
 
-  // Value gets populated if default value is populated.
-  if (current_path() == 'system/ajax' || (!$element['#value'] && !isset($form_state['input'][$element['#name']]['license_fieldset']['disabled'])) ||
-    (isset($element['#default_value']) && $element['#value'] == $element['#default_value'])) {
-    $element['#tree'] = TRUE;
-  }
-  else {
-    // I win form builder.
-    $element['#tree'] = FALSE;
-  }
-
-  $response = xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction, $disabled);
-  if ($response) {
-    $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = (string) $response->{'license-uri'};
-    $element['license_fieldset']['license_output'] = array(
-      '#type' => 'item',
-      '#id' => $license_output_id,
-      '#markup' => '<strong>' . t('Selected license:') . '</strong><div>' . $response->html->asXml() . '</div>',
-      '#states' => array(
-        'visible' => array(
-          ":input[name=\"{$element['#name']}[license_fieldset][disabled]\"]" => array('checked' => FALSE),
-        ),
+  $element['license_fieldset']['license_version'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Override License Version'),
+    '#description' => t('Optionally set to a previous version (leave empty to get newest).'),
+    '#size' => 3,
+    '#maxlength' => 3,
+    '#default_value' => $values['license_fieldset']['license_version'],
+    '#ajax' => array(
+      'wrapper' => $license_fieldset_id,
+      'callback' => 'xml_form_elements_creative_commons_ajax',
+      'keypress' => TRUE,
+    ),
+    '#states' => array(
+      'invisible' => array(
+        ":input[name=\"{$element['#name']}[license_fieldset][license_type]\"]" => array(array('value' => 'none'), array('value' => 'manual')),
       ),
-    );
+    ),
+  );
+
+  $element['license_fieldset']['license_uri'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Manually enter a license URI'),
+    '#description' => t('Note that you need to set the license type to "@option" for this to take effect.', array('@option' => $license_options['manual'])),
+    '#default_value' => $values['license_fieldset']['license_uri'],
+    '#ajax' => array(
+      'wrapper' => $license_fieldset_id,
+      'callback' => 'xml_form_elements_creative_commons_ajax',
+      'keypress' => TRUE,
+    ),
+    '#states' => array(
+      'invisible' => TRUE,
+      'visible' => array(
+        ":input[name=\"{$element['#name']}[license_fieldset][license_type]\"]" => array('value' => 'manual'),
+      ),
+    ),
+  );
+
+  // Prepare license output markup.
+  $cc_markup = t('None.');
+  // Only get markup if user wants a license and have a license URI set.
+  if ($values['license_fieldset']['license_type'] != 'none' && !empty($values['license_fieldset']['license_uri'])) {
+    // Get data from storage.
+    $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $values['license_fieldset']['license_uri']);
+    if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query']) &&
+      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] == $current_query &&
+      isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response']) &&
+      ($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] !== FALSE)) {
+      // Get response from storage.
+      $response = simplexml_load_string($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'], 'SimpleXMLElement');
+    }
+    else {
+      $response = xml_form_elements_get_creative_commons_from_uri($values['license_fieldset']['license_uri']);
+      // Cache response.
+      if (!isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data'])) {
+        $form_state['storage']['xml_form_elements'][$element['#name']]['api_data'] = array();
+      }
+      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] = $current_query;
+      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] = ($response !== FALSE) ? $response->asXML() : FALSE;
+    }
+    if ($response) {
+      if ($response->getName() == 'error') {
+        $cc_markup = t('None (form has errors).');
+      }
+      else {
+        $cc_markup = $response->html->asXml();
+        // Mend bogus <html> tags.
+        $cc_markup = preg_replace('#^<html>#', '<div>', $cc_markup);
+        $cc_markup = preg_replace('#</html>$#', '</div>', $cc_markup);
+      }
+    }
+    else {
+      $cc_markup = t('"@uri" (manually generated since Creative Commons API could not be reached).', array('@uri' => $values['license_fieldset']['license_uri']));
+    }
   }
-  else {
-    $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'] = xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction, $disabled);
-    $element['license_fieldset']['license_output'] = array();
-  }
+  // Generate markup element.
+  $element['license_fieldset']['license_output'] = array(
+    '#type' => 'item',
+    '#markup' => '<strong>' . t('Selected license:') . '</strong> ' . $cc_markup,
+    '#states' => array(
+      'invisible' => array(
+        ":input[name=\"{$element['#name']}[license_fieldset][license_type]\"]" => array('value' => 'none'),
+      ),
+    ),
+  );
+
+  // Element for graceful degradation w/out JS.
+  $element['license_fieldset']['license_update'] = array(
+    '#type' => 'button',
+    '#value' => t('Update license'),
+    '#weight' => 10,
+    '#limit_validation_errors' => array(),
+    '#submit' => array('xml_form_elements_creative_commons_license_update_submit'),
+    '#return_value' => 'update-license',
+    '#prefix' => '<noscript>',
+    '#suffix' => '</noscript>',
+  );
+
+  // Add validator.
+  $element['#element_validate'] = array('xml_form_elements_creative_commons_validate');
 
   return $element;
 }
 
 /**
+ * Submit handler for graceful no-JS degradation.
+ *
+ * @param array $form
+ *   The form.
+ * @param array $form_state
+ *   The form state.
+ */
+function xml_form_elements_creative_commons_license_update_submit($form, &$form_state) {
+  // If we have to manually update the form, force rebuild.
+  $form_state['rebuild'] = TRUE;
+}
+
+/**
+ * Validator for the `creative_commons` element.
+ *
+ * Validation is actually done elsewhere. We use this function only to set the
+ * element's value for form builder.
+ *
+ * @param array $element
+ *   The form element.
+ * @param array $form_state
+ *   The form state.
+ * @param array $form
+ *   The form.
+ */
+function xml_form_elements_creative_commons_validate(&$element, &$form_state, $form) {
+  // Set the value in $form_state so that form builder can use it.
+  $form_state['values'][$element['#name']] = is_string($element['#value']) ? $element['#value'] : $element['#value']['license_fieldset']['license_uri'];
+}
+
+/**
+ * Get current value array for `creative_commons` form element.
+ *
+ * @param array $element
+ *   The `creative_commons` form element.
+ * @param array|NULL $input
+ *   The user input (or NULL to retrieve defaults).
+ * @param array $form_state
+ *   The form state.
+ *
+ * @return array
+ *   The associative array representing the form values.
+ */
+function xml_form_elements_creative_commons_get_value_array_from_input(&$element, $input, &$form_state) {
+  // Get defaults (from element or, if unset, from the module).
+  $disabled_default = empty($element['#default_value']) ? XML_FORM_ELEMENTS_CREATIVE_COMMONS_DISABLED_DEFAULT : FALSE;
+  $license_uri_default = !empty($element['#default_value']) ? $element['#default_value'] : XML_FORM_ELEMENTS_CREATIVE_COMMONS_LICENSE_URI_DEFAULT;
+  list($license_default, $commercial_default, $derivatives_default, $version_default, $jurisdiction_default) = xml_form_elements_creative_commons_parse_uri($license_uri_default);
+  // If disabled, we set license type and license URI accordingly.
+  if ($disabled_default) {
+    $license_default = 'none';
+    $license_uri_default = '';
+  }
+  $error = FALSE;
+  // Read input if set, otherwise populate with defaults.
+  if (isset($input) && $input) {
+    $license = $input['license_fieldset']['license_type'];
+    // Disable if license is not recognized (or 'none').
+    if (!in_array($license, array('zero', 'mark', 'by', 'manual'))) {
+      $license = 'none';
+      $disabled = TRUE;
+    }
+    else {
+      $disabled = FALSE;
+    }
+    $commercial = $input['license_fieldset']['allow_commercial'];
+    $derivatives = $input['license_fieldset']['allow_modifications'];
+    $version = $input['license_fieldset']['license_version'];
+    // Clean up version.
+    if (!empty($version) && !preg_match("/^[0-9]\.[0-9]$/", $version)) {
+      $error = TRUE;
+      form_set_error($element['#name'] . '][license_fieldset][license_version', t("Invalid CC license version (leave empty for newest)."));
+    }
+    $jurisdiction = $input['license_fieldset']['license_jurisdiction'];
+    // Read license URI only if in 'manual' mode, otherwise wipe it.
+    if ($license == 'manual') {
+      $license_uri = isset($input['license_fieldset']['license_uri']) ? $input['license_fieldset']['license_uri'] : '';
+      // Clean up URI.
+      if (!empty($license_uri) && (
+        (strpos("#", $license_uri) !== FALSE) ||
+        !preg_match("#^" . XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL . "[a-z]+/[a-z+-]+/[0-9]\.[0-9]/([a-z]+/)?$#", $license_uri)
+      )) {
+        $error = TRUE;
+        form_set_error($element['#name'] . '][license_fieldset][license_uri', t("Invalid license URI format."));
+      }
+    }
+    else {
+      $license_uri = '';
+    }
+  }
+  else {
+    $disabled = $disabled_default;
+    $license = $license_default;
+    $commercial = $commercial_default;
+    $derivatives = $derivatives_default;
+    $version = $version_default;
+    $jurisdiction = $jurisdiction_default;
+    $license_uri = $license_uri_default;
+  }
+  if (!in_array($license, array('none', 'manual'))) {
+    // Check if there is a newer version unless user sets the URI manually.
+    $current_query = xml_form_elements_creative_commons_make_value_array($license, $derivatives, $commercial, $jurisdiction, '', '');
+    $response = FALSE;
+    if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['query']) &&
+      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['query'] == $current_query &&
+      isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['response']) &&
+      ($form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['response'] !== FALSE)) {
+      // Get response from storage.
+      $response = simplexml_load_string($form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['response'], 'SimpleXMLElement');
+    }
+    else {
+      $response = xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction, FALSE, '', $license);
+      // Cache response.
+      if (!isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get'])) {
+        $form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get'] = array();
+      }
+      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['query'] = $current_query;
+      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['response'] = ($response !== FALSE) ? $response->asXML() : FALSE;
+    }
+    if ($response) {
+      $license_uri = (string) $response->{'license-uri'};
+      $license_value_array = xml_form_elements_creative_commons_parse_uri($license_uri);
+      $new_version = $license_value_array[3];
+      if ($version != '') {
+        if ((float) $new_version < (float) $version) {
+          // The queried version is too high.
+          $error = TRUE;
+          form_set_error($element['#name'] . '][license_fieldset][license_version', t("CC license version not (yet) available (leave empty for newest)."));
+        }
+        elseif ((float) $new_version == (float) $version) {
+          // The queried version is already the newest.
+          $version = '';
+        }
+        else {
+          // The queried version is lower and we need to replace it in the URI.
+          $license_uri = str_replace($new_version, $version, $license_uri);
+          if ($license_uri == XML_FORM_ELEMENTS_CREATIVE_COMMONS_LICENSE_URI_DEFAULT) {
+            // Warn that the module default seems to be deprecated.
+            watchdog('xml_form_elements', 'Creative Commons default license seems to be deprecated. Please announce the developers.', array(), WATCHDOG_WARNING);
+          }
+          $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $license_uri);
+          if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query']) &&
+            $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] == $current_query &&
+            isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response']) &&
+            ($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] !== FALSE)) {
+            // Get response from storage.
+            $response = simplexml_load_string($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'], 'SimpleXMLElement');
+          }
+          else {
+            $response = xml_form_elements_get_creative_commons_from_uri($license_uri);
+            // Cache response.
+            if (!isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data'])) {
+              $form_state['storage']['xml_form_elements'][$element['#name']]['api_data'] = array();
+            }
+            $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] = $current_query;
+            $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] = ($response !== FALSE) ? $response->asXML() : FALSE;
+          }
+          if ($response) {
+            if ($response->getName() == 'error') {
+              // The license URI is not recognized.
+              $error = TRUE;
+              form_set_error($element['#name'] . '][license_fieldset][license_version', t("CC license version does not exist (leave empty for newest)."));
+            }
+          }
+          else {
+            drupal_set_message(t("Warning: Could not reach Creative Commons API to validate your input."));
+          }
+        }
+      }
+      else {
+        // Manually update cache for output.
+        $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $license_uri);
+        if (!isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data'])) {
+          $form_state['storage']['xml_form_elements'][$element['#name']]['api_data'] = array();
+        }
+        $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] = $current_query;
+        $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] = ($response !== FALSE) ? $response->asXML() : FALSE;
+      }
+    }
+    else {
+      // We have to build the license URI without the help of the API.
+      drupal_set_message(t('Warning: Could not query the Creative Commons API. Creating license manually.'));
+      $license_uri = xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction, FALSE, $version, $license);
+    }
+  }
+  elseif ($license == 'manual' && $license_uri != '') {
+    // Check manually entered license URI.
+    $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $license_uri);
+    if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query']) &&
+      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] == $current_query &&
+      isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response']) &&
+      ($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] !== FALSE)) {
+      // Get response from storage.
+      $response = simplexml_load_string($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'], 'SimpleXMLElement');
+    }
+    else {
+      $response = xml_form_elements_get_creative_commons_from_uri($license_uri);
+      // Cache response.
+      if (!isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data'])) {
+        $form_state['storage']['xml_form_elements'][$element['#name']]['api_data'] = array();
+      }
+      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] = $current_query;
+      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] = ($response !== FALSE) ? $response->asXML() : FALSE;
+    }
+    if ($response) {
+      // The license URI is not recognized.
+      if ($response->getName() == 'error') {
+        $error = TRUE;
+        form_set_error($element['#name'] . '][license_fieldset][license_uri', t("CC license URI seems to be invalid. Perhaps you would prefer to choose one automatically?"));
+      }
+    }
+    else {
+      // We could not reach the API.
+      drupal_set_message(t("Warning: Could not reach Creative Commons API to validate your input."));
+    }
+  }
+  // Force values into $form_state['input']
+  $form_state['input'][$element['#name']] = xml_form_elements_creative_commons_make_value_array($license, $derivatives, $commercial, $jurisdiction, $version, $license_uri);
+  // Return value array.
+  return $form_state['input'][$element['#name']];
+}
+
+/**
+ * Generate `creative_commons` value array.
+ *
+ * @param string $license
+ *   The license type.
+ * @param string $derivatives
+ *   Modifications.
+ * @param string $commercial
+ *   Commercial.
+ * @param string $jurisdiction
+ *   Legal jurisdiction code.
+ * @param string $version
+ *   License version.
+ * @param string $license_uri
+ *   License URI.
+ *
+ * @return array
+ *   The associative array representing the `creative_commons` input values.
+ */
+function xml_form_elements_creative_commons_make_value_array($license, $derivatives, $commercial, $jurisdiction, $version, $license_uri) {
+  return array(
+    'license_fieldset' => array(
+      'license_type' => $license,
+      'allow_modifications' => $derivatives,
+      'allow_commercial' => $commercial,
+      'license_jurisdiction' => $jurisdiction,
+      'license_version' => $version,
+      'license_uri' => $license_uri,
+    ));
+}
+
+/**
+ * Get API path for license.
+ *
+ * @param string $license
+ *   A string containing the license ('zero', 'mark', 'by' or 'sampling+').
+ *
+ * @return string|FALSE
+ *   The path where the license can be retrieved from using the API
+ *   ('zero', 'mark', 'recombo' or 'standard'), or FALSE if $license was
+ *   not recognized.
+ */
+function xml_form_elements_creative_commons_get_api_path($license) {
+  $zero = array('zero');
+  $mark = array('mark');
+  $recombo = array('sampling+');
+  $standard = array('by');
+  $subpath = '';
+  if (in_array($license, $zero)) {
+    $subpath = 'zero';
+  }
+  elseif (in_array($license, $mark)) {
+    $subpath = 'mark';
+  }
+  elseif (in_array($license, $recombo)) {
+    $subpath = 'recombo';
+  }
+  elseif (in_array($license, $standard)) {
+    $subpath = 'standard';
+  }
+  else {
+    return FALSE;
+  }
+  return 'license/' . $subpath . '/get';
+}
+
+/**
+ * Get path for license.
+ *
+ * @param string $license
+ *   A string containing the license ('zero', 'mark', 'by' or 'sampling+').
+ *
+ * @return string|FALSE
+ *   The path where the license is found ('licenses' or 'publicdomain'),
+ *   or FALSE if $license was not recognized.
+ */
+function xml_form_elements_creative_commons_get_license_path($license) {
+  $publicdomain = array('zero', 'mark');
+  $licenses = array('by', 'sampling+');
+  if (in_array($license, $publicdomain)) {
+    return 'publicdomain';
+  }
+  elseif (in_array($license, $licenses)) {
+    return 'licenses';
+  }
+  return FALSE;
+}
+
+/**
+ * Parse Creative Commons URI.
+ *
+ * @param string $license_uri
+ *   A string containing the CC license URI.
+ *
+ * @return array
+ *   An array containing:
+ *   - The license ('zero', 'mark', 'by' or 'sampling+')
+ *   - Commercial use ('y', 'n'; 'y' if license not 'by')
+ *   - Derivative creation ('y', 'n', 'sa'; 'y' if license not 'by')
+ *   - Jurisdiction (empty string if international or not applicable)
+ *   - Version
+ */
+function xml_form_elements_creative_commons_parse_uri($license_uri) {
+  $creative_commons_base_url = XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL;
+
+  // Reversing this array facilitates value_callback mangling by community.
+  $default_value_array = array_reverse(explode('/',
+    str_replace($creative_commons_base_url, "", $license_uri)
+  ));
+  // Remove the license path.
+  array_pop($default_value_array);
+  $properties = explode('-', array_pop($default_value_array));
+  $license = $properties[0];
+
+  $commercial = 'y';
+  $derivatives = 'y';
+
+  foreach ($properties as $property) {
+    switch ($property) {
+      case 'by':
+        break;
+
+      case 'nc':
+        $commercial = 'n';
+        break;
+
+      case 'nd':
+        $derivatives = 'n';
+        break;
+
+      case 'sa':
+        $derivatives = 'sa';
+        break;
+    }
+  }
+
+  $version = array_pop($default_value_array);
+
+  $jurisdiction = array_pop($default_value_array);
+
+  return array($license, $commercial, $derivatives, $version, $jurisdiction);
+}
+
+/**
  * Ajax callback to render the CC license.
+ *
+ * @param array $form
+ *   The form.
+ * @param array $form_state
+ *   The form state.
+ *
+ * @return array
+ *   The markup to replace the target (wrapper) with.
  */
 function xml_form_elements_creative_commons_ajax(&$form, &$form_state) {
   $parents = $form_state['triggering_element']['#parents'];
   array_pop($parents);
   $creative_commons_element = drupal_array_get_nested_value($form, $parents);
 
-  return $creative_commons_element['license_output'];
+  return $creative_commons_element;
 }
 
 /**
@@ -266,39 +691,89 @@ function xml_form_elements_creative_commons_ajax(&$form, &$form_state) {
  * @param string $commercial
  *   'y' to allow 'n' to disallow.
  * @param string $derivatives
- *   'y' to allow 'n' to disallow.
+ *   'y' to allow 'n' to disallow, 'sa' to share alike.
  * @param string $jurisdiction
  *   Legal jurisdiction code.
+ * @param bool $disabled
+ *   TRUE returns FALSE, FALSE (default) performs request.
+ * @param string $version
+ *   Specify (earlier) version (blank (default) for newest).
+ * @param string $license
+ *   Get licenses other than 'by' (default): 'zero', 'mark', 'sampling+'.
  *
  * @return mixed
  *   SimpleXMLElement the return from the REST API.
  *   FALSE if failed request.
  */
-function xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction, $disabled = FALSE) {
+function xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction, $disabled = FALSE, $version = '', $license = 'by') {
+  // Do not make request if disabled. Otherwise, either get an up-to-date
+  // license if $version is empty, or get license details if $version is
+  // specified.
   if ($disabled) {
     return FALSE;
   }
-  else {
-    $response = drupal_http_request(url(
-      'http://api.creativecommons.org/rest/1.5/license/standard/get',
-      array(
-        'query' => array(
-          'commercial' => $commercial,
-          'derivatives' => $derivatives,
-          'jurisdiction' => $jurisdiction,
-        ),
-      )
-    ));
-    if ($response->code != 200) {
-      error_log("xml_form responded {$response->code}");
-      return FALSE;
-    }
-    return simplexml_load_string($response->data, 'SimpleXMLElement');
+  elseif ($version != '') {
+    return xml_form_elements_get_creative_commons_from_uri(xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction, $disabled, $version, $license));
   }
+  $path = xml_form_elements_creative_commons_get_api_path($license);
+  if (!$path) {
+    $path = 'standard';
+  }
+  // $commercial, $derivatives and $jurisdiction only make sense for
+  // attribution licenses.
+  $response = drupal_http_request(url(
+    XML_FORM_ELEMENTS_CREATIVE_COMMONS_API_URL . $path,
+    ($license == 'by') ? array(
+      'query' => array(
+        'commercial' => $commercial,
+        'derivatives' => $derivatives,
+        'jurisdiction' => $jurisdiction,
+      ),
+    ) : array()
+  ));
+  if ($response->code != 200) {
+    error_log("xml_form responded {$response->code}");
+    return FALSE;
+  }
+  return simplexml_load_string($response->data, 'SimpleXMLElement');
 }
 
 /**
- * Gets the value for the element.
+ * Ask the creative commons REST API for a license based on URI.
+ *
+ * Left as a function for use by community modules.
+ *
+ * @param string $license_uri
+ *   A Creative Commonse license URI.
+ * @param bool $disabled
+ *   TRUE returns FALSE, FALSE (default) performs request.
+ *
+ * @return mixed
+ *   SimpleXMLElement the return from the REST API.
+ *   FALSE if failed request.
+ */
+function xml_form_elements_get_creative_commons_from_uri($license_uri, $disabled = FALSE) {
+  // Do not make request if disabled.
+  if ($disabled) {
+    return FALSE;
+  }
+  $response = drupal_http_request(url(
+    XML_FORM_ELEMENTS_CREATIVE_COMMONS_API_URL . 'details',
+    array(
+      'query' => array(
+        'license-uri' => $license_uri,
+      ),
+    )
+  ));
+  if ($response->code != 200) {
+    error_log("xml_form responded {$response->code}");
+    return FALSE;
+  }
+  return simplexml_load_string($response->data, 'SimpleXMLElement');
+}
+
+/**
+ * Gets the license URI value for the element.
  *
  * @param string $commercial
  *   'y' to allow 'n' to disallow.
@@ -306,17 +781,42 @@ function xml_form_elements_get_creative_commons($commercial, $derivatives, $juri
  *   'y' to allow 'n' to disallow.
  * @param string $jurisdiction
  *   Legal jurisdiction code.
+ * @param bool $disabled
+ *   TRUE returns empty string, FALSE (default) returns value.
+ * @param string $enforced_version
+ *   Override license version (empty string to take default).
+ * @param string $license
+ *   'by' (default), 'zero', 'mark'.
  *
  * @return string
- *   The value of the element.
+ *   The license URI value of the element.
+ *
+ * Note: $commercial, $derivatives and $jurisdiction are not parsed for
+ * licenses other than 'by', and we do not support the (deprecated!)
+ * 'sampling+'.
  */
-function xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction, $disabled = FALSE) {
+function xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction, $disabled = FALSE, $enforced_version = '', $license = 'by') {
+  // Return empty string if disabled.
   if ($disabled) {
     return '';
   }
+  $path = xml_form_elements_creative_commons_get_license_path($license);
+  // Default to 'by' if $license cannot be handled otherwise.
+  if (!$path || $license == 'sampling+') {
+    // Either we do not know the license, or it is the deprecated one.
+    $license = 'by';
+    $path = 'licenses';
+  }
+  $arguments = '';
+  if ($enforced_version !== '') {
+    // Select specified version.
+    $license_version = $enforced_version;
+  }
   else {
-    $license_version = '2.5';
-    $arguments = '';
+    // Default to versions that should be available.
+    $license_version = ($license == 'by') ? ($jurisdiction == 'international' ? 4.0 : '2.5') : '1.0';
+  }
+  if ($license == 'by') {
     if ($commercial == 'n') {
       $arguments = "$arguments-nc";
     }
@@ -326,15 +826,14 @@ function xml_form_elements_creative_commons_value($commercial, $derivatives, $ju
     elseif ($derivatives == 'sa') {
       $arguments = "$arguments-sa";
     }
-    if ($jurisdiction == 'international') {
-      $license_version = '4.0';
-      // Not needed for international.
-      $jurisdiction = '';
-    }
-    else {
-      // If not international add the trailing slash.
-      $jurisdiction .= '/';
-    }
-    return "http://creativecommons.org/licenses/by$arguments/$license_version/$jurisdiction";
   }
+  if ($license != 'by' || $jurisdiction == 'international') {
+    // Not needed for international or 'zero', 'mark' licenses.
+    $jurisdiction = '';
+  }
+  else {
+    // If not international add the trailing slash.
+    $jurisdiction .= '/';
+  }
+  return "http://creativecommons.org/licenses/$license$arguments/$license_version/$jurisdiction";
 }

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -551,7 +551,7 @@ function xml_form_elements_creative_commons_license_uri_has_valid_format($licens
   if (empty($license_uri) || (
     preg_match("#^" . XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL . "[a-z]+/[a-z+-]+/[0-9]\.[0-9]/([a-z]+/)?$#", $license_uri) &&
     (!preg_match("#/by[-/]#", $license_uri) ||
-      preg_match("#^" . XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL . xml_form_elements_creative_commons_get_license_path('by') . "/by((-nc)?(-nd|-sa?)|(-nd|-sa)?(-nc)?)/#", $license_uri))
+      preg_match("#^" . XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL . xml_form_elements_creative_commons_get_license_path('by') . "/by((-nc)?(-nd|-sa)?|(-nd|-sa)?(-nc)?)/#", $license_uri))
   )) {
     return TRUE;
   }

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -758,7 +758,7 @@ function xml_form_elements_creative_commons_process_input(&$element, $input, &$f
       // Get current version.
       $version = $values['license_fieldset']['license_version'];
       // Check version validity, if specified.
-      if ($version != '') {
+      if ($version != '' && (float) $new_version != (float) $version) {
         // Update the target license URI's version.
         $new_license_uri = str_replace($new_version, $version, $new_license_uri);
         // Compare versions.
@@ -767,12 +767,11 @@ function xml_form_elements_creative_commons_process_input(&$element, $input, &$f
           $error = TRUE;
           form_set_error($element['#name'] . '][license_fieldset][license_version', t("CC license version not (yet) available."));
         }
-        elseif ((float) $new_version == (float) $version) {
-          // The specified version is already the newest, so we empty it.
-          $values['license_fieldset']['license_version'] = '';
-        }
       }
       else {
+        // We queried the newest version, or the specified version is already
+        // the newest. We make sure the version is empty for the next request.
+        $values['license_fieldset']['license_version'] = '';
         // Manually update cache for output.
         $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $new_license_uri);
         xml_form_elements_creative_commons_store_api_response($element['#name'], 'api_data', $current_query, $response, $form_state);

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -558,6 +558,11 @@ function xml_form_elements_creative_commons_get_values_from_uri($license_uri) {
     xml_form_elements_creative_commons_make_value_array('manual', '', '', '', '', $license_uri)
   );
 
+  // If no license URI is set, default to no output.
+  if (empty($license_uri)) {
+    $values['license_fieldset']['license_type'] = 'none';
+  }
+
   // Parse URI only if it is non-empty and valid.
   if (!empty($license_uri) && xml_form_elements_creative_commons_license_uri_has_valid_format($license_uri)) {
     // Reversing this array facilitates value_callback mangling by community.

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -350,6 +350,9 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   // Add validator.
   $element['#element_validate'] = array('xml_form_elements_creative_commons_validate');
 
+  // Add javascript.
+  $element['#attached'] = array('js' => array(drupal_get_path('module', 'xml_form_elements') . '/js/creative_commons.js'));
+
   return $element;
 }
 

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -818,8 +818,8 @@ function xml_form_elements_creative_commons_get_processed_values(&$element, &$fo
   $empty_values = xml_form_elements_creative_commons_get_values_from_uri('');
 
   // If some values are missing, return filled-up value array.
-  $missing_values = array_diff_key($empty_values['license_fieldset'], $values['license_fieldset']);
-  if (!isset($values['license_fieldset']) || !empty($missing_values)) {
+  $missing_values = array('license_fieldset' => array_diff_key($empty_values['license_fieldset'], $values['license_fieldset']));
+  if (!isset($values['license_fieldset']) || !empty($missing_values['license_fieldset'])) {
     $values['license_fieldset'] = array_merge($empty_values['license_fieldset'], isset($values['license_fieldset']) ? $values['license_fieldset'] : array());
     drupal_set_message(t('An internal error occurred while processing the Creative Commons form element "@display_name" (unexpected data loss). Please inform the site administrator.', array("@display_name" => $element['license_fieldset']['#title'])), 'error');
     watchdog('xml_form_elements', 'Unexpected data loss when processing element "@element_name" in "@form_name". Probably you just found a bug.', array('@element_name' => $element['#name'], '@form_name' => $form_state['storage'][FormStorage::STORAGE_ROOT]['name']), WATCHDOG_ERROR);
@@ -976,7 +976,14 @@ function xml_form_elements_creative_commons_get_processed_values(&$element, &$fo
         // The license URI is not recognized.
         $error = TRUE;
         if ($values['license_fieldset']['license_type'] == 'manual') {
-          form_set_error($element['#name'] . '][license_fieldset][license_uri', t("CC license URI seems to be invalid. Perhaps you would prefer to choose one automatically?"));
+          // If only the jurisdiction was unknown, alert the user; otherwise
+          // suggest choosing the license automatically.
+          if (strpos($values['license_fieldset']['license_uri'], $new_license_uri) === 0) {
+            form_set_error($element['#name'] . '][license_fieldset][license_uri', t("CC license jurisdiction unknown or not applicable for this license."));
+          }
+          else {
+            form_set_error($element['#name'] . '][license_fieldset][license_uri', t("CC license URI seems to be invalid. Perhaps you would prefer to choose one automatically?"));
+          }
         }
         else {
           form_set_error($error_element, t("CC license version does not seem to exist."));

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -452,8 +452,14 @@ function xml_form_elements_creative_commons_get_value_array_from_input(&$element
   // In no error occurred, we reset all the variables based on the URI,
   // except for the license type.
   if (!$error && $license_uri != '') {
-    list($new_license, $commercial, $derivatives, $version, $jurisdiction) = xml_form_elements_creative_commons_parse_uri($license_uri);
+    list($new_license, $commercial, $derivatives, $new_version, $jurisdiction) = xml_form_elements_creative_commons_parse_uri($license_uri);
+    // Keep blank version only if not in manual mode.
+    if ($license == 'manual' || $version != '') {
+      $version = $new_version;
+    }
+    // Unset dummy variables.
     unset($new_license);
+    unset($new_version);
   }
   // Force values into $form_state['input']
   $form_state['input'][$element['#name']] = xml_form_elements_creative_commons_make_value_array($license, $derivatives, $commercial, $jurisdiction, $version, $license_uri);

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -10,42 +10,71 @@
  */
 const XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL = 'http://creativecommons.org/';
 const XML_FORM_ELEMENTS_CREATIVE_COMMONS_API_URL = 'https://api.creativecommons.org/rest/1.5/';
-const XML_FORM_ELEMENTS_CREATIVE_COMMONS_LICENSE_URI_DEFAULT = 'http://creativecommons.org/licenses/by/4.0/';
-const XML_FORM_ELEMENTS_CREATIVE_COMMONS_DISABLED_DEFAULT = TRUE;
 
 /**
- * Creates a `creative_commons` form element.
- *
- * @param array $form_state
- *   The form state.
+ * Returns license type options.
  *
  * @return array
- *   The element definition.
+ *   Associative array mapping types to descriptions.
  */
-function xml_form_elements_creative_commons($element, &$form_state) {
+function xml_form_elements_creative_commons_license_type_options() {
+  // Create the 'none' option.
+  $none_option = array('none' => t('Do not output any license'));
+  // Create the 'manual' option.
+  $manual_option = array('manual' => t('Manually enter a license URI'));
+  // Create license options.
+  // (Note: One could also retrieve this from the API; see
+  // https://api.creativecommons.org/docs/readme_15.html#locale-xx;
+  // however, make sure to provide at least the 'by' option not to break code.)
   $license_options = array(
-    'none' => t('Do not output any license'),
     'by' => t('Creative Commons Attribution'),
     'zero' => t('CC0 Universal (Public Domain)'),
     'mark' => t('Public Domain Mark'),
-    'manual' => t('Manually enter a license URI'),
   );
+  // Return options.
+  return array_merge($none_option, $license_options, $manual_option);
+}
 
-  $modification_options = array(
+/**
+ * Return derivative options for 'by' licenses.
+ *
+ * @return array
+ *   Associative array mapping options to descriptions.
+ */
+function xml_form_elements_creative_commons_derivative_options() {
+  return array(
     'y' => t('Yes'),
     'n' => t('No'),
     'sa' => t('Yes, as long as others share alike'),
   );
+}
 
-  $commercial_options = array(
+/**
+ * Return commercial options for 'by' licenses.
+ *
+ * @return array
+ *   Associative array mapping options to descriptions.
+ */
+function xml_form_elements_creative_commons_commercial_options() {
+  return array(
     'y' => t('Yes'),
     'n' => t('No'),
   );
+}
 
-  // List retrieved on 2018-04-28 from
-  // https://api.creativecommons.org/rest/1.5/support/jurisdictions
-  $countries = array(
-    'international' => t('International'),
+/**
+ * Return jurisdiction options for 'by' licenses.
+ *
+ * @return array
+ *   Associative array mapping options to descriptions.
+ */
+function xml_form_elements_creative_commons_jurisdiction_options() {
+  // Create 'international' option.
+  $international_option = array('' => t('International'));
+  // Create jursidiction options.
+  // (List retrieved on 2018-04-28 from
+  // https://api.creativecommons.org/rest/1.5/support/jurisdictions)
+  $jurisdiction_options = array(
     'ar' => t('Argentina'),
     'au' => t('Australia'),
     'at' => t('Austria'),
@@ -107,7 +136,21 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     've' => t('Venezuela'),
     'vn' => t('Vietnam'),
   );
+  return array_merge($international_option, $jurisdiction_options);
+}
 
+/**
+ * Creates a `creative_commons` form element.
+ *
+ * @param array $element
+ *   The form element.
+ * @param array $form_state
+ *   The form state.
+ *
+ * @return array
+ *   The element definition.
+ */
+function xml_form_elements_creative_commons($element, &$form_state) {
   // Get an ID for ajax.
   if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['license_fieldset_id'])) {
     $license_fieldset_id = $form_state['storage']['xml_form_elements'][$element['#name']]['license_fieldset_id'];
@@ -117,10 +160,15 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     $form_state['storage']['xml_form_elements'][$element['#name']]['license_fieldset_id'] = $license_fieldset_id;
   }
 
-  // Get current values and store them in the element.
+  // Get current values, process them and store them in the element.
   $input = isset($form_state['input'][$element['#name']]) ? $form_state['input'][$element['#name']] : NULL;
-  $values = xml_form_elements_creative_commons_get_value_array_from_input($element, $input, $form_state);
+  $values = xml_form_elements_creative_commons_process_input($element, $input, $form_state);
   $element['#value'] = $values;
+  // Force values into $form_state['input']
+  $form_state['input'][$element['#name']] = $values;
+
+  // Store the license type options in a variable.
+  $license_options = xml_form_elements_creative_commons_license_type_options();
 
   // Form elements.
 
@@ -144,12 +192,12 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     ),
   );
 
-  $element['license_fieldset']['allow_modifications'] = array(
+  $element['license_fieldset']['allow_derivatives'] = array(
     '#type' => 'select',
     '#title' => t('Allow modifications of your work?'),
     '#description' => t('Note that this is only relevant if you selected "@option" above.', array('@option' => $license_options['by'])),
-    '#options' => $modification_options,
-    '#default_value' => $values['license_fieldset']['allow_modifications'],
+    '#options' => xml_form_elements_creative_commons_derivative_options(),
+    '#default_value' => $values['license_fieldset']['allow_derivatives'],
     '#ajax' => array(
       'wrapper' => $license_fieldset_id,
       'callback' => 'xml_form_elements_creative_commons_ajax',
@@ -165,7 +213,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     '#type' => 'select',
     '#title' => t('Allow commercial uses of your work?'),
     '#description' => t('Note that this is only relevant if you selected "@option" above.', array('@option' => $license_options['by'])),
-    '#options' => $commercial_options,
+    '#options' => xml_form_elements_creative_commons_commercial_options(),
     '#default_value' => $values['license_fieldset']['allow_commercial'],
     '#ajax' => array(
       'wrapper' => $license_fieldset_id,
@@ -181,7 +229,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   $element['license_fieldset']['license_jurisdiction'] = array(
     '#type' => 'select',
     '#title' => t('License Jurisdiction'),
-    '#options' => $countries,
+    '#options' => xml_form_elements_creative_commons_jurisdiction_options(),
     '#description' => t('Note that this is only relevant if you selected "@option" above.', array('@option' => $license_options['by'])),
     '#default_value' => $values['license_fieldset']['license_jurisdiction'],
     '#ajax' => array(
@@ -232,26 +280,49 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     ),
   );
 
-  // Prepare license output markup.
-  $cc_markup = t('None.');
-  // Only get markup if user wants a license and have a license URI set.
-  if ($values['license_fieldset']['license_type'] != 'none' && !empty($values['license_fieldset']['license_uri'])) {
-    // Get data from storage.
-    $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $values['license_fieldset']['license_uri']);
-    $response = xml_form_elements_creative_commons_get_api_response($element['#name'], 'api_data', $current_query, $form_state);
-    if ($response) {
-      if ($response->getName() == 'error') {
-        $cc_markup = t('None (form has errors).');
-      }
-      else {
-        $cc_markup = $response->html->asXml();
-        // Mend bogus <html> tags.
-        $cc_markup = preg_replace('#^<html>#', '<div>', $cc_markup);
-        $cc_markup = preg_replace('#</html>$#', '</div>', $cc_markup);
+  // Get all form errors, attach 'error' class to erroneous elements and
+  // instruct the user to inform the admin if the error is due to a
+  // misconfiguration.
+  // Note: the first part is necessary when the error occurred on first load
+  // (but otherwise results in the 'error' class being attached twice).
+  $form_errors = form_get_errors();
+  if ($form_errors) {
+    foreach (array_keys($element['license_fieldset']) as $name) {
+      if (in_array($element['#name'] . '][license_fieldset][' . $name, array_keys($form_errors))) {
+        $element['license_fieldset'][$name]['#attributes']['class'][] = 'error';
       }
     }
-    else {
+    if (!$input) {
+      // There was no input, so the form was probably built from the previous
+      // step. Hence, it is likely that we are displaying the site default,
+      // so the admin should be warned.
+      drupal_set_message(t('It is likely that the Creative Commons form element "@display_name" has been misconfigured. Please inform the site administrator.', array('@display_name' => $element['license_fieldset']['#title'])), 'error');
+      watchdog('xml_form_elements', 'It is likely that the Creative Commons form element "@element_name" has been misconfigured.', array('@element_name' => $element['#name']), WATCHDOG_WARNING);
+    }
+  }
+
+  // Prepare license output markup.
+  $cc_markup = $form_errors ? t('None (form has errors).') : t('None.');
+  // Only get API markup if the form has no errors, the user wants a license and
+  // we have a license URI set.
+  if (!$form_errors && $values['license_fieldset']['license_type'] != 'none' && !empty($values['license_fieldset']['license_uri'])) {
+    // Get data from storage.
+    $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $values['license_fieldset']['license_uri']);
+    $response = xml_form_elements_creative_commons_retrieve_api_response($element['#name'], 'api_data', $current_query, $form_state);
+    if (!$response) {
       $cc_markup = t('"@uri" (manually generated since Creative Commons API could not be reached).', array('@uri' => $values['license_fieldset']['license_uri']));
+    }
+    elseif ($response->getName() == 'error') {
+      // We should never be here.
+      drupal_set_message(t('An unexpected error occurred with the Creative Commons form element "@display_name". Please inform the site administrator.', array('@display_name' => $element['license_fieldset']['#title'])), 'error');
+      watchdog('xml_form_elements', 'The Creative Commons API returned an error on "@uri" that should have been cought already. Probably you just found a bug.', array('@uri' => $element['license_fieldset']['license_uri']), WATCHDOG_WARNING);
+    }
+    else {
+      // Get the HTML markup for the selected license.
+      $cc_markup = $response->html->asXml();
+      // Mend bogus <html> tags.
+      $cc_markup = preg_replace('#^<html>#', '<div>', $cc_markup);
+      $cc_markup = preg_replace('#</html>$#', '</div>', $cc_markup);
     }
   }
   // Generate markup element.
@@ -280,6 +351,25 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   $element['#element_validate'] = array('xml_form_elements_creative_commons_validate');
 
   return $element;
+}
+
+/**
+ * Ajax callback to render the CC license.
+ *
+ * @param array $form
+ *   The form.
+ * @param array $form_state
+ *   The form state.
+ *
+ * @return array
+ *   The markup to replace the target (wrapper) with.
+ */
+function xml_form_elements_creative_commons_ajax(&$form, &$form_state) {
+  $parents = $form_state['triggering_element']['#parents'];
+  array_pop($parents);
+  $creative_commons_element = drupal_array_get_nested_value($form, $parents);
+
+  return $creative_commons_element;
 }
 
 /**
@@ -314,166 +404,12 @@ function xml_form_elements_creative_commons_validate(&$element, &$form_state, $f
 }
 
 /**
- * Get current value array for `creative_commons` form element.
- *
- * @param array $element
- *   The `creative_commons` form element.
- * @param array|NULL $input
- *   The user input (or NULL to retrieve defaults).
- * @param array $form_state
- *   The form state.
- *
- * @return array
- *   The associative array representing the form values.
- */
-function xml_form_elements_creative_commons_get_value_array_from_input(&$element, $input, &$form_state) {
-  // Get defaults (from element or, if unset, from the module).
-  $disabled_default = empty($element['#default_value']) ? XML_FORM_ELEMENTS_CREATIVE_COMMONS_DISABLED_DEFAULT : FALSE;
-  $license_uri_default = !empty($element['#default_value']) ? $element['#default_value'] : XML_FORM_ELEMENTS_CREATIVE_COMMONS_LICENSE_URI_DEFAULT;
-  list($license_default, $commercial_default, $derivatives_default, $version_default, $jurisdiction_default) = xml_form_elements_creative_commons_parse_uri($license_uri_default);
-  // If disabled, we set license type and license URI accordingly.
-  if ($disabled_default) {
-    $license_default = 'none';
-    $license_uri_default = '';
-  }
-  $error = FALSE;
-  // Read input if set, otherwise populate with defaults.
-  if (isset($input) && $input) {
-    $license = $input['license_fieldset']['license_type'];
-    // Disable if license is not recognized (or 'none').
-    if (!in_array($license, array('zero', 'mark', 'by', 'manual'))) {
-      $license = 'none';
-      $disabled = TRUE;
-    }
-    else {
-      $disabled = FALSE;
-    }
-    $commercial = $input['license_fieldset']['allow_commercial'];
-    $derivatives = $input['license_fieldset']['allow_modifications'];
-    $version = $input['license_fieldset']['license_version'];
-    // Clean up version.
-    if (!empty($version) && !preg_match("/^[0-9]\.[0-9]$/", $version)) {
-      $error = TRUE;
-      form_set_error($element['#name'] . '][license_fieldset][license_version', t("Invalid CC license version (leave empty for newest)."));
-    }
-    $jurisdiction = $input['license_fieldset']['license_jurisdiction'];
-    // Read license URI only if in 'manual' mode, otherwise wipe it.
-    if ($license == 'manual') {
-      $license_uri = isset($input['license_fieldset']['license_uri']) ? $input['license_fieldset']['license_uri'] : '';
-      // Clean up URI.
-      if (!empty($license_uri) && (
-        (strpos("#", $license_uri) !== FALSE) ||
-        !preg_match("#^" . XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL . "[a-z]+/[a-z+-]+/[0-9]\.[0-9]/([a-z]+/)?$#", $license_uri)
-      )) {
-        $error = TRUE;
-        form_set_error($element['#name'] . '][license_fieldset][license_uri', t("Invalid license URI format."));
-      }
-    }
-    else {
-      $license_uri = '';
-    }
-  }
-  else {
-    $disabled = $disabled_default;
-    $license = $license_default;
-    $commercial = $commercial_default;
-    $derivatives = $derivatives_default;
-    $version = $version_default;
-    $jurisdiction = $jurisdiction_default;
-    $license_uri = $license_uri_default;
-  }
-  if (!in_array($license, array('none', 'manual'))) {
-    // Check if there is a newer version unless user sets the URI manually.
-    $current_query = xml_form_elements_creative_commons_make_value_array($license, $derivatives, $commercial, $jurisdiction, '', '');
-    $response = xml_form_elements_creative_commons_get_api_response($element['#name'], 'api_data_get', $current_query, $form_state);
-    if ($response) {
-      $license_uri = (string) $response->{'license-uri'};
-      $license_value_array = xml_form_elements_creative_commons_parse_uri($license_uri);
-      $new_version = $license_value_array[3];
-      if ($version != '') {
-        if ((float) $new_version < (float) $version) {
-          // The queried version is too high.
-          $error = TRUE;
-          form_set_error($element['#name'] . '][license_fieldset][license_version', t("CC license version not (yet) available (leave empty for newest)."));
-        }
-        elseif ((float) $new_version == (float) $version) {
-          // The queried version is already the newest.
-          $version = '';
-        }
-        else {
-          // The queried version is lower and we need to replace it in the URI.
-          $license_uri = str_replace($new_version, $version, $license_uri);
-          if ($license_uri == XML_FORM_ELEMENTS_CREATIVE_COMMONS_LICENSE_URI_DEFAULT) {
-            // Warn that the module default seems to be deprecated.
-            watchdog('xml_form_elements', 'Creative Commons default license seems to be deprecated. Please announce the developers.', array(), WATCHDOG_WARNING);
-          }
-          $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $license_uri);
-          $response = xml_form_elements_creative_commons_get_api_response($element['#name'], 'api_data', $current_query, $form_state);
-          if ($response) {
-            if ($response->getName() == 'error') {
-              // The license URI is not recognized.
-              $error = TRUE;
-              form_set_error($element['#name'] . '][license_fieldset][license_version', t("CC license version does not exist (leave empty for newest)."));
-            }
-          }
-          else {
-            drupal_set_message(t("Warning: Could not reach Creative Commons API to validate your input."));
-          }
-        }
-      }
-      else {
-        // Manually update cache for output.
-        $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $license_uri);
-        xml_form_elements_creative_commons_store_api_response($element['#name'], 'api_data', $current_query, $response, $form_state);
-      }
-    }
-    else {
-      // We have to build the license URI without the help of the API.
-      drupal_set_message(t('Warning: Could not query the Creative Commons API. Creating license manually.'));
-      $license_uri = xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction, FALSE, $version, $license);
-    }
-  }
-  elseif ($license == 'manual' && $license_uri != '') {
-    // Check manually entered license URI.
-    $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $license_uri);
-    $response = xml_form_elements_creative_commons_get_api_response($element['#name'], 'api_data', $current_query, $form_state);
-    if ($response) {
-      if ($response->getName() == 'error') {
-        // The license URI is not recognized.
-        $error = TRUE;
-        form_set_error($element['#name'] . '][license_fieldset][license_uri', t("CC license URI seems to be invalid. Perhaps you would prefer to choose one automatically?"));
-      }
-    }
-    else {
-      // We could not reach the API.
-      drupal_set_message(t("Warning: Could not reach Creative Commons API to validate your input."));
-    }
-  }
-  // In no error occurred, we reset all the variables based on the URI,
-  // except for the license type.
-  if (!$error && $license_uri != '') {
-    list($new_license, $commercial, $derivatives, $new_version, $jurisdiction) = xml_form_elements_creative_commons_parse_uri($license_uri);
-    // Keep blank version only if not in manual mode.
-    if ($license == 'manual' || $version != '') {
-      $version = $new_version;
-    }
-    // Unset dummy variables.
-    unset($new_license);
-    unset($new_version);
-  }
-  // Force values into $form_state['input']
-  $form_state['input'][$element['#name']] = xml_form_elements_creative_commons_make_value_array($license, $derivatives, $commercial, $jurisdiction, $version, $license_uri);
-  // Return value array.
-  return $form_state['input'][$element['#name']];
-}
-
-/**
  * Generate `creative_commons` value array.
  *
  * @param string $license
  *   The license type.
  * @param string $derivatives
- *   Modifications.
+ *   Derivatives.
  * @param string $commercial
  *   Commercial.
  * @param string $jurisdiction
@@ -490,12 +426,396 @@ function xml_form_elements_creative_commons_make_value_array($license, $derivati
   return array(
     'license_fieldset' => array(
       'license_type' => $license,
-      'allow_modifications' => $derivatives,
+      'allow_derivatives' => $derivatives,
       'allow_commercial' => $commercial,
       'license_jurisdiction' => $jurisdiction,
       'license_version' => $version,
       'license_uri' => $license_uri,
     ));
+}
+
+/**
+ * Get path for license.
+ *
+ * @param string $license
+ *   A string containing the license ('zero', 'mark', 'by' or 'sampling+').
+ *
+ * @return string|FALSE
+ *   The path where the license is found ('licenses' or 'publicdomain'),
+ *   or FALSE if $license was not recognized.
+ */
+function xml_form_elements_creative_commons_get_license_path($license) {
+  $publicdomain = array('zero', 'mark');
+  $licenses = array('by', 'sampling+');
+  if (in_array($license, $publicdomain)) {
+    return 'publicdomain';
+  }
+  elseif (in_array($license, $licenses)) {
+    return 'licenses';
+  }
+  return FALSE;
+}
+
+/**
+ * Test the Creative Commons version format validity.
+ *
+ * @param string $license_version
+ *   The license version.
+ *
+ * @return bool
+ *   TRUE if format is valid, FALSE otherwise.
+ */
+function xml_form_elements_creative_commons_license_version_has_valid_format($license_version) {
+  if (empty($license_version) || preg_match("#^[0-9]\.[0-9]$#", $license_version)) {
+    return TRUE;
+  }
+  return FALSE;
+}
+
+/**
+ * Test the Creative Commons license URI format validity.
+ *
+ * @param string $license_uri
+ *   The license URI.
+ *
+ * @return bool
+ *   TRUE if format is valid, FALSE otherwise.
+ */
+function xml_form_elements_creative_commons_license_uri_has_valid_format($license_uri) {
+  if (empty($license_uri) || (
+    preg_match("#^" . XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL . "[a-z]+/[a-z+-]+/[0-9]\.[0-9]/([a-z]+/)?$#", $license_uri) &&
+    (!preg_match("#/by#", $license_uri) ||
+      preg_match("#^" . XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL . xml_form_elements_creative_commons_get_license_path('by') . "/by((-nc)?(-nd|-sa?)|(-nd|-sa)?(-nc)?)/#", $license_uri))
+  )) {
+    return TRUE;
+  }
+  return FALSE;
+}
+
+/**
+ * Quick value array clean-up.
+ *
+ * @param array $values
+ *   The value array.
+ *
+ * @return array
+ *   The cleaned-up value array.
+ */
+function xml_form_elements_creative_commons_cleanup_values($values) {
+  // Get all allowed options.
+  $allowed_licenses = array_keys(xml_form_elements_creative_commons_license_type_options());
+  $by_options = array();
+  $by_options['allow_derivatives'] = array_keys(xml_form_elements_creative_commons_derivative_options());
+  $by_options['allow_commercial'] = array_keys(xml_form_elements_creative_commons_commercial_options());
+  $by_options['license_jurisdiction'] = array_keys(xml_form_elements_creative_commons_jurisdiction_options());
+  // Check if queried license type exists, reset to 'none' otherwise.
+  if (!in_array($values['license_fieldset']['license_type'], $allowed_licenses)) {
+    $values['license_fieldset']['license_type'] = 'none';
+  }
+  // Clean up selected 'by' options.
+  if ($values['license_fieldset']['license_type'] != 'by') {
+    // Reset derivative, commercial and jurisdiction options when not 'by'.
+    foreach ($by_options as $key => $opts) {
+      $values['license_fieldset'][$key] = $opts[0];
+    }
+  }
+  else {
+    // Check if all selected options exist, reset them otherwise.
+    foreach ($by_options as $key => $opts) {
+      if (!in_array($values['license_fieldset'][$key], $opts)) {
+        $values['license_fieldset'][$key] = $opts[0];
+      }
+    }
+  }
+  // Clean up version.
+  if (in_array($values['license_fieldset']['license_type'], array('none', 'manual'))) {
+    $values['license_fieldset']['license_version'] = '';
+  }
+  // Nuke license URI if not in manual mode.
+  if ($values['license_fieldset']['license_type'] != 'manual') {
+    $values['license_fieldset']['license_uri'] = '';
+  }
+  // Return cleaned-up user values.
+  return $values;
+}
+
+/**
+ * Create CC element value array from license URI.
+ *
+ * @param string $license_uri
+ *   The CC license URI.
+ *
+ * @return array
+ *   The associative value array corresponding to the URI.
+ */
+function xml_form_elements_creative_commons_get_values_from_uri($license_uri) {
+  // Get supported licenses (assuming 'by', as well as the special values
+  // 'none' and 'manual').
+  $supported_licenses = array_diff(array_keys(xml_form_elements_creative_commons_license_type_options()), array('none', 'manual'));
+
+  // Make a default array based on the URI.
+  $values = xml_form_elements_creative_commons_cleanup_values(
+    xml_form_elements_creative_commons_make_value_array('manual', '', '', '', '', $license_uri)
+  );
+
+  // Parse URI only if it is non-empty and valid.
+  if (!empty($license_uri) && xml_form_elements_creative_commons_license_uri_has_valid_format($license_uri)) {
+    // Reversing this array facilitates value_callback mangling by community.
+    $uri_value_array = array_reverse(explode('/',
+      preg_replace('#^' . XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL . '#', '', $license_uri)
+    ));
+    // Remove the license path.
+    array_pop($uri_value_array);
+    // Get license with properties.
+    $properties = explode('-', array_pop($uri_value_array));
+    // If the license is supported, set the type.
+    if (in_array($properties[0], $supported_licenses)) {
+      $values['license_fieldset']['license_type'] = $properties[0];
+    }
+    // Parse 'by' options.
+    if ($properties[0] == 'by') {
+      foreach ($properties as $property) {
+        switch ($property) {
+          case 'by':
+            break;
+
+          case 'nc':
+            $values['license_fieldset']['allow_commercial'] = 'n';
+            break;
+
+          case 'nd':
+            $values['license_fieldset']['allow_derivatives'] = 'n';
+            break;
+
+          case 'sa':
+            $values['license_fieldset']['allow_derivatives'] = 'sa';
+            break;
+        }
+      }
+    }
+    // Get version.
+    $values['license_fieldset']['license_version'] = array_pop($uri_value_array);
+    // Get jurisdiction.
+    $values['license_fieldset']['license_jurisdiction'] = array_pop($uri_value_array);
+    // Clean up jurisdiction.
+    $supported_jurisdictions = array_keys(xml_form_elements_creative_commons_jurisdiction_options());
+    if (!in_array($values['license_fieldset']['license_jurisdiction'], $supported_jurisdictions)) {
+      $values['license_fieldset']['license_jurisdiction'] = $supported_jurisdictions[0];
+    }
+  }
+
+  // Return the parsed values including the license URI.
+  return $values;
+}
+
+/**
+ * Create license URI from CC element value array.
+ *
+ * @param array $values
+ *   The associative value array corresponding to the URI.
+ *
+ * @return string
+ *   The CC license URI.
+ */
+function xml_form_elements_creative_commons_get_uri_from_values($values) {
+  // Return empty string if license type 'none' was specified.
+  if ($values['license_fieldset']['license_type'] == 'none') {
+    return '';
+  }
+  // Return the specified license URI when in manual mode.
+  if ($values['license_fieldset']['license_type'] == 'manual') {
+    return $values['license_fieldset']['license_uri'];
+  }
+  // Get the specified license.
+  $license = $values['license_fieldset']['license_type'];
+  // Get supported licenses (assuming 'by', as well as the special values
+  // 'none' and 'manual').
+  $supported_licenses = array_diff(array_keys(xml_form_elements_creative_commons_license_type_options()), array('none', 'manual'));
+  // Get the path for the specified license.
+  $path = xml_form_elements_creative_commons_get_license_path($license);
+  // Return the specified license URI if the license or its path are unknown.
+  if (!in_array($license, $supported_licenses) || $path === FALSE) {
+    return $values['license_fieldset']['license_uri'];
+  }
+  // Get the license arguments for 'by'.
+  $arguments = '';
+  if ($license == 'by') {
+    if ($values['license_fieldset']['allow_commercial'] == 'n') {
+      $arguments = "$arguments-nc";
+    }
+    if ($values['license_fieldset']['allow_derivatives'] == 'n') {
+      $arguments = "$arguments-nd";
+    }
+    elseif ($values['license_fieldset']['allow_derivatives'] == 'sa') {
+      $arguments = "$arguments-sa";
+    }
+  }
+  // Get the specified jurisdiction.
+  $jurisdiction = $values['license_fieldset']['license_jurisdiction'];
+  // Clean up jurisdiction if non-empty.
+  if (!empty($jurisdiction)) {
+    // Get the supported jurisdictions (assuming the first one should map
+    // to '').
+    $supported_jurisdictions = array_keys(xml_form_elements_creative_commons_jurisdiction_options());
+    // Empty jurisdiction if not supported or first (default) choice; otherwise
+    // append a slash.
+    if (!in_array($jurisdiction, $supported_jurisdictions) || $jurisdiction == $supported_jurisdictions[0]) {
+      $jurisdiction = '';
+    }
+    else {
+      $jurisdiction .= '/';
+    }
+  }
+  // Get the specified version.
+  $version = $values['license_fieldset']['license_version'];
+  // If no version was specified, default to versions that should be available.
+  if (empty($version)) {
+    $version = ($license == 'by') ? ($jurisdiction == '' ? '4.0' : '2.5') : '1.0';
+  }
+  // Return the license URI.
+  return XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL . "$path/$license$arguments/$version/$jurisdiction";
+}
+
+/**
+ * Process input and get values for `creative_commons` form element.
+ *
+ * @param array $element
+ *   The `creative_commons` form element.
+ * @param array|NULL $input
+ *   The user input (or NULL to retrieve defaults).
+ * @param array $form_state
+ *   The form state.
+ *
+ * @return array
+ *   The associative array representing the form element values.
+ *
+ * Note that validation for the `creative_commons` element is done whithin this
+ * function. This has the side effect that users cannot go to the previous step
+ * in a mulit-step form before resolving erroneous choices.
+ */
+function xml_form_elements_creative_commons_process_input(&$element, $input, &$form_state) {
+  // Get defaults from element, if available.
+  $default_values = xml_form_elements_creative_commons_get_values_from_uri(isset($element['#default_value']) ? $element['#default_value'] : '');
+  // Set initial values.
+  $values = !empty($input) ? xml_form_elements_creative_commons_cleanup_values($input) : $default_values;
+  // If no output was requested, return.
+  if ($values['license_fieldset']['license_type'] == 'none') {
+    return $values;
+  }
+  // If in manual mode, try to guess the license, but reset to manual.
+  if ($values['license_fieldset']['license_type'] == 'manual') {
+    $values = xml_form_elements_creative_commons_get_values_from_uri($values['license_fieldset']['license_uri']);
+    $values['license_fieldset']['license_type'] = 'manual';
+  }
+  // If in manual mode with no license URI set, return.
+  if ($values['license_fieldset']['license_type'] == 'manual' && empty($values['license_fieldset']['license_uri'])) {
+    return $values;
+  }
+
+  // Know if we have errors.
+  $error = FALSE;
+
+  // Validate the initial version.
+  if (!xml_form_elements_creative_commons_license_version_has_valid_format($values['license_fieldset']['license_version'])) {
+    $error = TRUE;
+    form_set_error($element['#name'] . '][license_fieldset][license_version', t('Invalid CC license version format.'));
+  }
+
+  // Validate the initial license URI.
+  if (!xml_form_elements_creative_commons_license_uri_has_valid_format($values['license_fieldset']['license_uri'])) {
+    $error = TRUE;
+    $test_uri = preg_replace('#^https?#', 'http', preg_replace('#/?$#', '/', $values['license_fieldset']['license_uri'], 1));
+    if (xml_form_elements_creative_commons_license_uri_has_valid_format($test_uri)) {
+      form_set_error($element['#name'] . '][license_fieldset][license_uri', t('The CC license URI needs to start with "http://" and end with a slash "/".'));
+    }
+    else {
+      form_set_error($element['#name'] . '][license_fieldset][license_uri', t('Invalid CC license URI format.'));
+    }
+  }
+
+  // If there was an error, return.
+  if ($error) {
+    return $values;
+  }
+
+  // Check if there is a newer version unless user sets the URI manually.
+  if (!in_array($values['license_fieldset']['license_type'], array('none', 'manual'))) {
+    // Prepare the API query (keep only what's needed).
+    $current_query = $values;
+    $current_query['license_fieldset']['license_version'] = '';
+    $current_query['license_fieldset']['license_uri'] = '';
+    $response = xml_form_elements_creative_commons_retrieve_api_response($element['#name'], 'api_data_get', $current_query, $form_state);
+    if ($response && $response->getName() != 'error') {
+      // Get the newest license URI and get its version.
+      $new_license_uri = (string) $response->{'license-uri'};
+      $new_values = xml_form_elements_creative_commons_get_values_from_uri($new_license_uri);
+      $new_version = $new_values['license_fieldset']['license_version'];
+      // Get current version.
+      $version = $values['license_fieldset']['license_version'];
+      // Check version validity, if specified.
+      if ($version != '') {
+        // Update the target license URI's version.
+        $new_license_uri = str_replace($new_version, $version, $new_license_uri);
+        // Compare versions.
+        if ((float) $new_version < (float) $version) {
+          // The specified version is too high.
+          $error = TRUE;
+          form_set_error($element['#name'] . '][license_fieldset][license_version', t("CC license version not (yet) available."));
+        }
+        elseif ((float) $new_version == (float) $version) {
+          // The specified version is already the newest, so we empty it.
+          $values['license_fieldset']['license_version'] = '';
+        }
+      }
+      else {
+        // Manually update cache for output.
+        $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $new_license_uri);
+        xml_form_elements_creative_commons_store_api_response($element['#name'], 'api_data', $current_query, $response, $form_state);
+      }
+    }
+    else {
+      // We have to build the license URI without the help of the API.
+      if (!$response) {
+        drupal_set_message(t("Could not query the Creative Commons API. Creating license URI manually."), 'warning');
+      }
+      elseif ($response->getName() == 'error') {
+        drupal_set_message(t("The Creative Commons API unexpectedly returned an error. Creating license URI manually."), 'warning');
+      }
+      $new_license_uri = xml_form_elements_creative_commons_get_uri_from_values($values);
+    }
+    // Store the new license URI.
+    $values['license_fieldset']['license_uri'] = $new_license_uri;
+  }
+
+  // If there was an error, return.
+  if ($error) {
+    return $values;
+  }
+
+  // Check the URI we are about to return.
+  if (!empty($values['license_fieldset']['license_uri'])) {
+    $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $values['license_fieldset']['license_uri']);
+    $response = xml_form_elements_creative_commons_retrieve_api_response($element['#name'], 'api_data', $current_query, $form_state);
+    if ($response) {
+      if ($response->getName() == 'error') {
+        // The license URI is not recognized.
+        $error = TRUE;
+        if ($values['license_fieldset']['license_type'] == 'manual') {
+          form_set_error($element['#name'] . '][license_fieldset][license_uri', t("CC license URI seems to be invalid. Perhaps you would prefer to choose one automatically?"));
+        }
+        else {
+          form_set_error($element['#name'] . '][license_fieldset][license_version', t("CC license version does not seem to exist."));
+        }
+      }
+    }
+    else {
+      // We could not reach the API.
+      drupal_set_message(t("Could not reach Creative Commons API to validate your input."), 'warning');
+    }
+  }
+
+  // Return the values for the form element.
+  return $values;
 }
 
 /**
@@ -534,102 +854,50 @@ function xml_form_elements_creative_commons_get_api_path($license) {
 }
 
 /**
- * Get path for license.
+ * Get a license from the CC API.
  *
- * @param string $license
- *   A string containing the license ('zero', 'mark', 'by' or 'sampling+').
+ * @param string $path
+ *   The path from which to query.
+ * @param array $options
+ *   The http query array to attach to the query.
  *
- * @return string|FALSE
- *   The path where the license is found ('licenses' or 'publicdomain'),
- *   or FALSE if $license was not recognized.
+ * @return SimpleXMLElement|FALSE
+ *   The response from the REST API as a SimpleXMLElement, or FALSE if request
+ *   failed.
+ *
+ * Note that there may be a bug in the CC API. Querying, e.g., 'fi'
+ * jurisdiction, 'sa' derivatives and 'y' or 'n' commercial, results in a
+ * CC-BY-SA/CC-BY-NC-SA 4.0 International license, instead of the corresponding
+ * 1.0 Finland version (which exists and is not deprecated).
+ * This behaviour, unfortunately, breaks our logic, so users will have to
+ * insert those licenses manually, and admins cannot set them as default.
  */
-function xml_form_elements_creative_commons_get_license_path($license) {
-  $publicdomain = array('zero', 'mark');
-  $licenses = array('by', 'sampling+');
-  if (in_array($license, $publicdomain)) {
-    return 'publicdomain';
+function xml_form_elements_creative_commons_query_api_get($path, $options = array()) {
+  $response = drupal_http_request(url(XML_FORM_ELEMENTS_CREATIVE_COMMONS_API_URL . $path, array('query' => $options)));
+  if ($response->code != 200) {
+    watchdog('xml_form_elements', 'The Creative Commons API responded with code %code.', array('%code' => $response->code), WATCHDOG_WARNING);
+    return FALSE;
   }
-  elseif (in_array($license, $licenses)) {
-    return 'licenses';
-  }
-  return FALSE;
+  return simplexml_load_string($response->data, 'SimpleXMLElement');
 }
 
 /**
- * Parse Creative Commons URI.
+ * Get license details from the CC API.
  *
  * @param string $license_uri
- *   A string containing the CC license URI.
+ *   The license URI for which to query details.
  *
- * @return array
- *   An array containing:
- *   - The license ('zero', 'mark', 'by' or 'sampling+')
- *   - Commercial use ('y', 'n'; 'y' if license not 'by')
- *   - Derivative creation ('y', 'n', 'sa'; 'y' if license not 'by')
- *   - Jurisdiction ('international' if international or not applicable)
- *   - Version
+ * @return SimpleXMLElement|FALSE
+ *   The response from the REST API as a SimpleXMLElement, or FALSE if request
+ *   failed.
  */
-function xml_form_elements_creative_commons_parse_uri($license_uri) {
-  $creative_commons_base_url = XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL;
-
-  // Reversing this array facilitates value_callback mangling by community.
-  $default_value_array = array_reverse(explode('/',
-    str_replace($creative_commons_base_url, "", $license_uri)
-  ));
-  // Remove the license path.
-  array_pop($default_value_array);
-  $properties = explode('-', array_pop($default_value_array));
-  $license = $properties[0];
-
-  $commercial = 'y';
-  $derivatives = 'y';
-
-  foreach ($properties as $property) {
-    switch ($property) {
-      case 'by':
-        break;
-
-      case 'nc':
-        $commercial = 'n';
-        break;
-
-      case 'nd':
-        $derivatives = 'n';
-        break;
-
-      case 'sa':
-        $derivatives = 'sa';
-        break;
-    }
+function xml_form_elements_creative_commons_query_api_details($license_uri) {
+  $response = drupal_http_request(url(XML_FORM_ELEMENTS_CREATIVE_COMMONS_API_URL . 'details', array('query' => array('license-uri' => $license_uri))));
+  if ($response->code != 200) {
+    watchdog('xml_form_elements', 'The Creative Commons API responded with code %code.', array('%code' => $response->code), WATCHDOG_WARNING);
+    return FALSE;
   }
-
-  $version = array_pop($default_value_array);
-
-  $jurisdiction = array_pop($default_value_array);
-  if (empty($jurisdiction)) {
-    $jurisdiction = 'international';
-  }
-
-  return array($license, $commercial, $derivatives, $version, $jurisdiction);
-}
-
-/**
- * Ajax callback to render the CC license.
- *
- * @param array $form
- *   The form.
- * @param array $form_state
- *   The form state.
- *
- * @return array
- *   The markup to replace the target (wrapper) with.
- */
-function xml_form_elements_creative_commons_ajax(&$form, &$form_state) {
-  $parents = $form_state['triggering_element']['#parents'];
-  array_pop($parents);
-  $creative_commons_element = drupal_array_get_nested_value($form, $parents);
-
-  return $creative_commons_element;
+  return simplexml_load_string($response->data, 'SimpleXMLElement');
 }
 
 /**
@@ -672,7 +940,7 @@ function xml_form_elements_creative_commons_store_api_response($element_name, $s
  *   SimpleXMLElement the return from the REST API.
  *   FALSE if failed request.
  */
-function xml_form_elements_creative_commons_get_api_response($element_name, $storage_folder, $values, &$form_state) {
+function xml_form_elements_creative_commons_retrieve_api_response($element_name, $storage_folder, $values, &$form_state) {
   if (isset($form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['query']) &&
     $form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['query'] == $values &&
     isset($form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['response']) &&
@@ -681,11 +949,27 @@ function xml_form_elements_creative_commons_get_api_response($element_name, $sto
     $response = simplexml_load_string($form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['response'], 'SimpleXMLElement');
   }
   else {
-    if (!empty($values['license_fieldset']['license_uri'])) {
-      $response = xml_form_elements_get_creative_commons_from_uri($values['license_fieldset']['license_uri'], FALSE);
+    if (empty($values['license_fieldset']['license_uri'])) {
+      // Without specified URI, get a fresh license based on input values.
+      $api_path = xml_form_elements_creative_commons_get_api_path($values['license_fieldset']['license_type']);
+      // Default to standard for unknown licenses.
+      if (!$api_path) {
+        $api_path = 'license/standard/get';
+      }
+      // Prepare query options.
+      $api_options = array();
+      if ($values['license_fieldset']['license_type'] == 'by') {
+        $api_options = array(
+          'commercial' => $values['license_fieldset']['allow_commercial'],
+          'derivatives' => $values['license_fieldset']['allow_derivatives'],
+          'jurisdiction' => $values['license_fieldset']['license_jurisdiction'],
+        );
+      }
+      $response = xml_form_elements_creative_commons_query_api_get($api_path, $api_options);
     }
     else {
-      $response = xml_form_elements_get_creative_commons($values['license_fieldset']['allow_commercial'], $values['license_fieldset']['allow_modifications'], $values['license_fieldset']['license_jurisdiction'], FALSE, $values['license_fieldset']['license_version'], $values['license_fieldset']['license_type']);
+      // Get the license details for the specified license URI.
+      $response = xml_form_elements_creative_commons_query_api_details($values['license_fieldset']['license_uri']);
     }
     // Cache response.
     xml_form_elements_creative_commons_store_api_response($element_name, $storage_folder, $values, $response, $form_state);
@@ -694,156 +978,80 @@ function xml_form_elements_creative_commons_get_api_response($element_name, $sto
 }
 
 /**
- * Ask the creative commons REST API for a license.
+ * Ask the creative commons REST API for a 'by' license.
  *
  * Left as a function for use by community modules.
  *
+ * @deprecated As of release 7.x-1.11, this function remains only for backwards
+ *   compatibilty. New code should use
+ *   xml_form_elements_creative_commons_query_api_get() instead.
+ *   Update your code, as this function might be removed.
+ *
  * @param string $commercial
- *   'y' to allow 'n' to disallow.
+ *   'y' to allow, 'n' to disallow.
  * @param string $derivatives
- *   'y' to allow 'n' to disallow, 'sa' to share alike.
+ *   'y' to allow, 'n' to disallow, 'sa' to share alike.
  * @param string $jurisdiction
  *   Legal jurisdiction code.
  * @param bool $disabled
- *   TRUE returns FALSE, FALSE (default) performs request.
- * @param string $version
- *   Specify (earlier) version (blank (default) for newest).
- * @param string $license
- *   Get licenses other than 'by' (default): 'zero', 'mark', 'sampling+'.
+ *   If TRUE, return FALSE; otherwise perform query.
  *
  * @return mixed
  *   SimpleXMLElement the return from the REST API.
  *   FALSE if failed request.
  */
-function xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction, $disabled = FALSE, $version = '', $license = 'by') {
-  // Do not make request if disabled. Otherwise, either get an up-to-date
-  // license if $version is empty, or get license details if $version is
-  // specified.
+function xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction, $disabled = FALSE) {
+  // Show deprecated message.
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  $deprecated_message = islandora_deprecated('7.x-1.11', t('Use @newfunction() instead.', array('@newfunction' => 'xml_form_elements_creative_commons_query_api_get')));
+  trigger_error(filter_xss($deprecated_message), E_USER_DEPRECATED);
+  // Return FALSE if disabled.
   if ($disabled) {
     return FALSE;
   }
-  elseif ($version != '') {
-    return xml_form_elements_get_creative_commons_from_uri(xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction, $disabled, $version, $license));
-  }
-  $path = xml_form_elements_creative_commons_get_api_path($license);
-  if (!$path) {
-    $path = 'standard';
-  }
-  // $commercial, $derivatives and $jurisdiction only make sense for
-  // attribution licenses.
-  $response = drupal_http_request(url(
-    XML_FORM_ELEMENTS_CREATIVE_COMMONS_API_URL . $path,
-    ($license == 'by') ? array(
-      'query' => array(
-        'commercial' => $commercial,
-        'derivatives' => $derivatives,
-        'jurisdiction' => $jurisdiction,
-      ),
-    ) : array()
-  ));
-  if ($response->code != 200) {
-    error_log("xml_form responded {$response->code}");
-    return FALSE;
-  }
-  return simplexml_load_string($response->data, 'SimpleXMLElement');
+  // This function only pertains to 'by' licenses.
+  $api_path = 'license/standard/get';
+  // Prepare query options.
+  $api_options = array(
+    'commercial' => $commercial,
+    'derivatives' => $derivatives,
+    'jurisdiction' => $jurisdiction,
+  );
+  // Return API response.
+  return xml_form_elements_creative_commons_query_api_get($api_path, $api_options);
 }
 
 /**
- * Ask the creative commons REST API for a license based on URI.
+ * Gets the 'by' license URI for the element.
  *
- * Left as a function for use by community modules.
- *
- * @param string $license_uri
- *   A Creative Commonse license URI.
- * @param bool $disabled
- *   TRUE returns FALSE, FALSE (default) performs request.
- *
- * @return mixed
- *   SimpleXMLElement the return from the REST API.
- *   FALSE if failed request.
- */
-function xml_form_elements_get_creative_commons_from_uri($license_uri, $disabled = FALSE) {
-  // Do not make request if disabled.
-  if ($disabled) {
-    return FALSE;
-  }
-  $response = drupal_http_request(url(
-    XML_FORM_ELEMENTS_CREATIVE_COMMONS_API_URL . 'details',
-    array(
-      'query' => array(
-        'license-uri' => $license_uri,
-      ),
-    )
-  ));
-  if ($response->code != 200) {
-    error_log("xml_form responded {$response->code}");
-    return FALSE;
-  }
-  return simplexml_load_string($response->data, 'SimpleXMLElement');
-}
-
-/**
- * Gets the license URI value for the element.
+ * @deprecated As of release 7.x-1.11, this function remains only for backwards
+ *   compatibilty. New code should use
+ *   xml_form_elements_creative_commons_get_uri_from_values() instead.
+ *   Update your code, as this function might be removed.
  *
  * @param string $commercial
- *   'y' to allow 'n' to disallow.
+ *   'y' to allow, 'n' to disallow.
  * @param string $derivatives
- *   'y' to allow 'n' to disallow.
+ *   'y' to allow, 'n' to disallow, 'sa' to share alike.
  * @param string $jurisdiction
  *   Legal jurisdiction code.
  * @param bool $disabled
- *   TRUE returns empty string, FALSE (default) returns value.
- * @param string $enforced_version
- *   Override license version (empty string to take default).
- * @param string $license
- *   'by' (default), 'zero', 'mark'.
+ *   If TRUE, return empty string; otherwise generate the URI.
  *
  * @return string
- *   The license URI value of the element.
- *
- * Note: $commercial, $derivatives and $jurisdiction are not parsed for
- * licenses other than 'by', and we do not support the (deprecated!)
- * 'sampling+'.
+ *   The value of the element.
  */
-function xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction, $disabled = FALSE, $enforced_version = '', $license = 'by') {
+function xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction, $disabled = FALSE) {
+  // Show deprecated message.
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  $deprecated_message = islandora_deprecated('7.x-1.11', t('Use @newfunction() instead.', array('@newfunction' => 'xml_form_elements_creative_commons_get_uri_from_values')));
+  trigger_error(filter_xss($deprecated_message), E_USER_DEPRECATED);
   // Return empty string if disabled.
   if ($disabled) {
     return '';
   }
-  $path = xml_form_elements_creative_commons_get_license_path($license);
-  // Default to 'by' if $license cannot be handled otherwise.
-  if (!$path || $license == 'sampling+') {
-    // Either we do not know the license, or it is the deprecated one.
-    $license = 'by';
-    $path = 'licenses';
-  }
-  $arguments = '';
-  if ($enforced_version !== '') {
-    // Select specified version.
-    $license_version = $enforced_version;
-  }
-  else {
-    // Default to versions that should be available.
-    $license_version = ($license == 'by') ? ($jurisdiction == 'international' ? 4.0 : '2.5') : '1.0';
-  }
-  if ($license == 'by') {
-    if ($commercial == 'n') {
-      $arguments = "$arguments-nc";
-    }
-    if ($derivatives == 'n') {
-      $arguments = "$arguments-nd";
-    }
-    elseif ($derivatives == 'sa') {
-      $arguments = "$arguments-sa";
-    }
-  }
-  if ($license != 'by' || $jurisdiction == 'international') {
-    // Not needed for international or 'zero', 'mark' licenses.
-    $jurisdiction = '';
-  }
-  else {
-    // If not international add the trailing slash.
-    $jurisdiction .= '/';
-  }
-  return "http://creativecommons.org/licenses/$license$arguments/$license_version/$jurisdiction";
+  // Generate form element values based on parameters.
+  $values = xml_form_elements_creative_commons_make_value_array('by', $derivatives, $commercial, $jurisdiction, '', '');
+  // Return the license URI.
+  return xml_form_elements_creative_commons_get_uri_from_values($values);
 }

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -1153,7 +1153,7 @@ function _xml_form_elements_creative_commons_query_api($path, $query = array()) 
  *
  * @return mixed
  *   SimpleXMLElement the return from the REST API.
- *   FALSE if failed request.
+ *   FALSE if failed request or if `$disabled` evaluates to `TRUE`.
  */
 function xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction, $disabled = FALSE) {
   // Show deprecated message.
@@ -1194,7 +1194,8 @@ function xml_form_elements_get_creative_commons($commercial, $derivatives, $juri
  *   If TRUE, return empty string; otherwise generate the URI.
  *
  * @return string
- *   The value of the element.
+ *   The value of the element, or the empty string `''` if `$disabled`
+ *   evaluates to `TRUE`.
  */
 function xml_form_elements_creative_commons_value($commercial, $derivatives, $jurisdiction, $disabled = FALSE) {
   // Show deprecated message.

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -12,7 +12,7 @@ const XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL = 'http://creativecommons.org/
 const XML_FORM_ELEMENTS_CREATIVE_COMMONS_API_URL = 'https://api.creativecommons.org/rest/1.5/';
 
 /**
- * Returns license type options.
+ * Return license type options.
  *
  * @return array
  *   Associative array mapping types to descriptions.
@@ -140,7 +140,7 @@ function xml_form_elements_creative_commons_jurisdiction_options() {
 }
 
 /**
- * Creates a `creative_commons` form element.
+ * Create a `creative_commons` form element.
  *
  * @param array $element
  *   The form element.
@@ -160,18 +160,12 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     $form_state['storage']['xml_form_elements'][$element['#name']]['license_fieldset_id'] = $license_fieldset_id;
   }
 
-  // Get current values, process them and store them in the element.
-  $input = isset($form_state['input'][$element['#name']]) ? $form_state['input'][$element['#name']] : NULL;
-  $values = xml_form_elements_creative_commons_process_input($element, $input, $form_state);
-  $element['#value'] = $values;
-  // Force values into $form_state['input']
-  $form_state['input'][$element['#name']] = $values;
-
   // Store the license type options in a variable.
   $license_options = xml_form_elements_creative_commons_license_type_options();
 
-  // Form elements.
+  // Form elements that need to be populated.
 
+  // The wrapping field set.
   $element['license_fieldset'] = array(
     '#id' => $license_fieldset_id,
     '#type' => 'fieldset',
@@ -180,24 +174,26 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     '#title' => t('License'),
   );
 
+  // License type chooser.
   $element['license_fieldset']['license_type'] = array(
     '#type' => 'select',
     '#title' => t('Select a license type'),
     '#description' => t('Select "@option" to avoid outputting a creative commons license. This will still output a blank element in the resulting XML, so make sure to use a cleanup template to remove it.', array('@option' => $license_options['none'])),
-    '#options' => $license_options,
-    '#default_value' => $values['license_fieldset']['license_type'],
+    '#empty_option' => $license_options['none'],
+    '#empty_value' => 'none',
+    '#options' => array_diff_key($license_options, array('none' => '')),
     '#ajax' => array(
       'wrapper' => $license_fieldset_id,
       'callback' => 'xml_form_elements_creative_commons_ajax',
     ),
   );
 
+  // Allow modification chooser for 'by' licenses.
   $element['license_fieldset']['allow_derivatives'] = array(
     '#type' => 'select',
     '#title' => t('Allow modifications of your work?'),
     '#description' => t('Note that this is only relevant if you selected "@option" above.', array('@option' => $license_options['by'])),
     '#options' => xml_form_elements_creative_commons_derivative_options(),
-    '#default_value' => $values['license_fieldset']['allow_derivatives'],
     '#ajax' => array(
       'wrapper' => $license_fieldset_id,
       'callback' => 'xml_form_elements_creative_commons_ajax',
@@ -209,12 +205,12 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     ),
   );
 
+  // Allow commercial chooser for 'by' licenses.
   $element['license_fieldset']['allow_commercial'] = array(
     '#type' => 'select',
     '#title' => t('Allow commercial uses of your work?'),
     '#description' => t('Note that this is only relevant if you selected "@option" above.', array('@option' => $license_options['by'])),
     '#options' => xml_form_elements_creative_commons_commercial_options(),
-    '#default_value' => $values['license_fieldset']['allow_commercial'],
     '#ajax' => array(
       'wrapper' => $license_fieldset_id,
       'callback' => 'xml_form_elements_creative_commons_ajax',
@@ -226,12 +222,12 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     ),
   );
 
+  // Jurisdiction chooser for 'by' licenses.
   $element['license_fieldset']['license_jurisdiction'] = array(
     '#type' => 'select',
     '#title' => t('License Jurisdiction'),
     '#options' => xml_form_elements_creative_commons_jurisdiction_options(),
     '#description' => t('Note that this is only relevant if you selected "@option" above.', array('@option' => $license_options['by'])),
-    '#default_value' => $values['license_fieldset']['license_jurisdiction'],
     '#ajax' => array(
       'wrapper' => $license_fieldset_id,
       'callback' => 'xml_form_elements_creative_commons_ajax',
@@ -243,13 +239,11 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     ),
   );
 
-  $element['license_fieldset']['license_version'] = array(
-    '#type' => 'textfield',
+  // Version overriding checkbox.
+  $element['license_fieldset']['override_license_version'] = array(
+    '#type' => 'checkbox',
     '#title' => t('Override License Version'),
-    '#description' => t('Optionally set to a previous version (leave empty to get newest).'),
-    '#size' => 3,
-    '#maxlength' => 3,
-    '#default_value' => $values['license_fieldset']['license_version'],
+    '#description' => t('Optionally set to a previous version.'),
     '#ajax' => array(
       'wrapper' => $license_fieldset_id,
       'callback' => 'xml_form_elements_creative_commons_ajax',
@@ -262,11 +256,31 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     ),
   );
 
+  // Version text field.
+  $element['license_fieldset']['license_version'] = array(
+    '#type' => 'textfield',
+    '#title' => t('License Version'),
+    '#description' => t('Choose a license version (leave empty to get newest). Note that this only takes effect if you checked "@title" above.', array('@title' => $element['license_fieldset']['override_license_version']['#title'])),
+    '#size' => 3,
+    '#maxlength' => 3,
+    '#ajax' => array(
+      'wrapper' => $license_fieldset_id,
+      'callback' => 'xml_form_elements_creative_commons_ajax',
+      'keypress' => TRUE,
+    ),
+    '#states' => array(
+      'invisible' => array(
+        array(":input[name=\"{$element['#name']}[license_fieldset][license_type]\"]" => array(array('value' => 'none'), array('value' => 'manual'))),
+        array(":input[name=\"{$element['#name']}[license_fieldset][override_license_version]\"]" => array('checked' => FALSE)),
+      ),
+    ),
+  );
+
+  // License URI text field.
   $element['license_fieldset']['license_uri'] = array(
     '#type' => 'textfield',
     '#title' => t('Manually enter a license URI'),
     '#description' => t('Note that you need to set the license type to "@option" for this to take effect.', array('@option' => $license_options['manual'])),
-    '#default_value' => $values['license_fieldset']['license_uri'],
     '#ajax' => array(
       'wrapper' => $license_fieldset_id,
       'callback' => 'xml_form_elements_creative_commons_ajax',
@@ -280,55 +294,9 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     ),
   );
 
-  // Get all form errors, attach 'error' class to erroneous elements and
-  // instruct the user to inform the admin if the error is due to a
-  // misconfiguration.
-  // Note: the first part is necessary when the error occurred on first load
-  // (but otherwise results in the 'error' class being attached twice).
-  $form_errors = form_get_errors();
-  if ($form_errors) {
-    foreach (array_keys($element['license_fieldset']) as $name) {
-      if (in_array($element['#name'] . '][license_fieldset][' . $name, array_keys($form_errors))) {
-        $element['license_fieldset'][$name]['#attributes']['class'][] = 'error';
-      }
-    }
-    if (!$input) {
-      // There was no input, so the form was probably built from the previous
-      // step. Hence, it is likely that we are displaying the site default,
-      // so the admin should be warned.
-      drupal_set_message(t('It is likely that the Creative Commons form element "@display_name" has been misconfigured. Please inform the site administrator.', array('@display_name' => $element['license_fieldset']['#title'])), 'error');
-      watchdog('xml_form_elements', 'It is likely that the Creative Commons form element "@element_name" has been misconfigured.', array('@element_name' => $element['#name']), WATCHDOG_WARNING);
-    }
-  }
-
-  // Prepare license output markup.
-  $cc_markup = $form_errors ? t('None (form has errors).') : t('None.');
-  // Only get API markup if the form has no errors, the user wants a license and
-  // we have a license URI set.
-  if (!$form_errors && $values['license_fieldset']['license_type'] != 'none' && !empty($values['license_fieldset']['license_uri'])) {
-    // Get data from storage.
-    $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $values['license_fieldset']['license_uri']);
-    $response = xml_form_elements_creative_commons_retrieve_api_response($element['#name'], 'api_data', $current_query, $form_state);
-    if (!$response) {
-      $cc_markup = t('"@uri" (manually generated since Creative Commons API could not be reached).', array('@uri' => $values['license_fieldset']['license_uri']));
-    }
-    elseif ($response->getName() == 'error') {
-      // We should never be here.
-      drupal_set_message(t('An unexpected error occurred with the Creative Commons form element "@display_name". Please inform the site administrator.', array('@display_name' => $element['license_fieldset']['#title'])), 'error');
-      watchdog('xml_form_elements', 'The Creative Commons API returned an error on "@uri" that should have been cought already. Probably you just found a bug.', array('@uri' => $element['license_fieldset']['license_uri']), WATCHDOG_WARNING);
-    }
-    else {
-      // Get the HTML markup for the selected license.
-      $cc_markup = $response->html->asXml();
-      // Mend bogus <html> tags.
-      $cc_markup = preg_replace('#^<html>#', '<div>', $cc_markup);
-      $cc_markup = preg_replace('#</html>$#', '</div>', $cc_markup);
-    }
-  }
-  // Generate markup element.
+  // License markup element.
   $element['license_fieldset']['license_output'] = array(
     '#type' => 'item',
-    '#markup' => '<strong>' . t('Selected license:') . '</strong> ' . $cc_markup,
     '#states' => array(
       'invisible' => array(
         ":input[name=\"{$element['#name']}[license_fieldset][license_type]\"]" => array('value' => 'none'),
@@ -336,11 +304,11 @@ function xml_form_elements_creative_commons($element, &$form_state) {
     ),
   );
 
-  // Element for graceful degradation w/out JS.
+  // Update button for graceful degradation w/out JS.
   $element['license_fieldset']['license_update'] = array(
     '#type' => 'button',
     '#value' => t('Update license'),
-    '#limit_validation_errors' => array(),
+    '#limit_validation_errors' => array(array($element['#name'])),
     '#submit' => array('xml_form_elements_creative_commons_license_update_submit'),
     '#return_value' => 'update-license',
     '#prefix' => '<noscript>',
@@ -353,7 +321,83 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   // Add javascript.
   $element['#attached'] = array('js' => array(drupal_get_path('module', 'xml_form_elements') . '/js/creative_commons.js'));
 
+  // If there is no input, or the temporary storage contains data (meaning
+  // that the validator already exectued), populate the element with values.
+  if (!isset($form_state['input'][$element['#name']]) || isset($form_state['temporary'][$element['#name']])) {
+    _xml_form_elements_creative_commons_populate_element($element, $form_state);
+  }
+
+  // Get all form errors, attach 'error' class to erroneous elements and
+  // instruct the user to inform the admin if the error is due to a
+  // misconfiguration.
+  // Note: the first part is necessary when the error occurred on first load
+  // (but otherwise results in the 'error' class being attached twice).
+  $form_errors = form_get_errors();
+  if ($form_errors) {
+    foreach (array_keys($element['license_fieldset']) as $name) {
+      if (in_array($element['#name'] . '][license_fieldset][' . $name, array_keys($form_errors))) {
+        $element['license_fieldset'][$name]['#attributes']['class'][] = 'error';
+      }
+    }
+    if (empty($form_state['input'][$element['#name']])) {
+      // There was no input, so the form was probably built from the previous
+      // step. Hence, it is likely that we are displaying the site default,
+      // so the admin should be warned.
+      drupal_set_message(t('It is likely that the Creative Commons form element "@display_name" has been misconfigured. Please inform the site administrator.', array('@display_name' => $element['license_fieldset']['#title'])), 'error');
+      watchdog('xml_form_elements', 'It is likely that the Creative Commons form element "@element_name" in "@form_name" has been misconfigured.', array('@element_name' => $element['#name'], '@form_name' => $form_state['storage'][FormStorage::STORAGE_ROOT]['name']), WATCHDOG_WARNING);
+    }
+  }
+
   return $element;
+}
+
+/**
+ * Helper function to populate `creative_commons` elements.
+ *
+ * @param array $element
+ *   The form element.
+ * @param array $form_state
+ *   The form state.
+ *
+ * Note: only call this after all the elements have been defined.
+ */
+function _xml_form_elements_creative_commons_populate_element(&$element, &$form_state) {
+  // If this is not the first run, get markup and values from temporary
+  // storage; otherwise call utility function to process user input, resp.
+  // the default value, and store the data.
+  if (isset($form_state['temporary'][$element['#name']])) {
+    list($markup, $values) = $form_state['temporary'][$element['#name']];
+  }
+  else {
+    list($markup, $values) = xml_form_elements_creative_commons_get_processed_values($element, $form_state);
+    $form_state['temporary'][$element['#name']] = array($markup, $values);
+  }
+
+  // Update $form_state values.
+  form_set_value($element, $values, $form_state);
+
+  // Update element value.
+  $element['#value'] = $values;
+
+  // Populate elements' values and default values.
+  foreach ($values['license_fieldset'] as $key => $val) {
+    $element['license_fieldset'][$key]['#value'] = $val;
+    $element['license_fieldset'][$key]['#default_value'] = $val;
+  }
+
+  // Set license output markup.
+  $element['license_fieldset']['license_output']['#markup'] = $markup;
+
+  // Set required elements when necessary.
+  if ($element['#required']) {
+    $element['license_fieldset']['license_type']['#required'] = ($values['license_fieldset']['license_type'] != 'manual');
+    $element['license_fieldset']['license_uri']['#required'] = ($values['license_fieldset']['license_type'] == 'manual');
+  }
+
+  // Nuke the description of the type chooser when none was chosen.
+  if ($element['license_fieldset']['license_type']['#value'] == 'none') {
+    unset($element['license_fieldset']['license_type']['#description']);
+  }
 }
 
 /**
@@ -391,9 +435,6 @@ function xml_form_elements_creative_commons_license_update_submit($form, &$form_
 /**
  * Validator for the `creative_commons` element.
  *
- * Validation is actually done elsewhere. We use this function only to set the
- * element's value for form builder.
- *
  * @param array $element
  *   The form element.
  * @param array $form_state
@@ -402,8 +443,27 @@ function xml_form_elements_creative_commons_license_update_submit($form, &$form_
  *   The form.
  */
 function xml_form_elements_creative_commons_validate(&$element, &$form_state, $form) {
-  // Set the value in $form_state so that form builder can use it.
-  $form_state['values'][$element['#name']] = is_string($element['#value']) ? $element['#value'] : $element['#value']['license_fieldset']['license_uri'];
+  // Make sure creative commons form errors get displayed.
+  $validation_sections =& drupal_static('form_set_error' . ':limit_validation_errors');
+  $original_validation_sections = $validation_sections;
+  $validation_sections = array(array($element['#name']));
+  // Populate element.
+  _xml_form_elements_creative_commons_populate_element($element, $form_state);
+  // If a license is required, error if none was chosen.
+  if (($element['license_fieldset']['license_type']['#value'] == 'none') && $element['license_fieldset']['license_type']['#required']) {
+    form_set_error($element['#name'] . '][license_fieldset][license_type', t('@element is required.', array('@element' => $element['license_fieldset']['license_type']['#title'])));
+  }
+  // If a license is required, error if no URI was given in manual mode.
+  if (($element['license_fieldset']['license_type']['#value'] == 'manual') && $form_state['values'][$element['#name']]['license_fieldset']['license_uri'] == '' && $element['license_fieldset']['license_uri']['#required']) {
+    form_set_error($element['#name'] . '][license_fieldset][license_uri', t('@element is required.', array('@element' => $element['license_fieldset']['license_uri']['#title'])));
+  }
+  // Re-set validation sections.
+  $validation_sections = $original_validation_sections;
+  // If user submits, set the scalar value in $form_state so that form builder
+  // can use it.
+  if ($form_state['submitted'] && !$form_state['rebuild']) {
+    $form_state['values'][$element['#name']] = is_string($element['#value']) ? $element['#value'] : $element['#value']['license_fieldset']['license_uri'];
+  }
 }
 
 /**
@@ -417,6 +477,8 @@ function xml_form_elements_creative_commons_validate(&$element, &$form_state, $f
  *   Commercial.
  * @param string $jurisdiction
  *   Legal jurisdiction code.
+ * @param bool $override_version
+ *   TRUE to override version, FALSE to get newest.
  * @param string $version
  *   License version.
  * @param string $license_uri
@@ -425,13 +487,14 @@ function xml_form_elements_creative_commons_validate(&$element, &$form_state, $f
  * @return array
  *   The associative array representing the `creative_commons` input values.
  */
-function xml_form_elements_creative_commons_make_value_array($license, $derivatives, $commercial, $jurisdiction, $version, $license_uri) {
+function xml_form_elements_creative_commons_make_value_array($license, $derivatives, $commercial, $jurisdiction, $override_version, $version, $license_uri) {
   return array(
     'license_fieldset' => array(
       'license_type' => $license,
       'allow_derivatives' => $derivatives,
       'allow_commercial' => $commercial,
       'license_jurisdiction' => $jurisdiction,
+      'override_license_version' => $override_version,
       'license_version' => $version,
       'license_uri' => $license_uri,
     ));
@@ -487,7 +550,7 @@ function xml_form_elements_creative_commons_license_version_has_valid_format($li
 function xml_form_elements_creative_commons_license_uri_has_valid_format($license_uri) {
   if (empty($license_uri) || (
     preg_match("#^" . XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL . "[a-z]+/[a-z+-]+/[0-9]\.[0-9]/([a-z]+/)?$#", $license_uri) &&
-    (!preg_match("#/by#", $license_uri) ||
+    (!preg_match("#/by[-/]#", $license_uri) ||
       preg_match("#^" . XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL . xml_form_elements_creative_commons_get_license_path('by') . "/by((-nc)?(-nd|-sa?)|(-nd|-sa)?(-nc)?)/#", $license_uri))
   )) {
     return TRUE;
@@ -496,50 +559,83 @@ function xml_form_elements_creative_commons_license_uri_has_valid_format($licens
 }
 
 /**
- * Quick value array clean-up.
+ * Quick input array clean-up.
  *
- * @param array $values
- *   The value array.
+ * @param array $input
+ *   The input array.
  *
  * @return array
- *   The cleaned-up value array.
+ *   The cleaned-up input array.
  */
-function xml_form_elements_creative_commons_cleanup_values($values) {
+function xml_form_elements_creative_commons_cleanup_input($input) {
+  // Define dummy element.
+  $dummy_input = xml_form_elements_creative_commons_make_value_array(NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+  // Reset to dummy element when $input is null or does not have the expected
+  // format.
+  if (empty($input) || !isset($input['license_fieldset'])) {
+    $input = $dummy_input;
+  }
+  // Nuke unexpected keys.
+  $input = array_intersect_key($input, $dummy_input);
+  $input['license_fieldset'] = array_intersect_key($input['license_fieldset'], $dummy_input['license_fieldset']);
   // Get all allowed options.
   $allowed_licenses = array_keys(xml_form_elements_creative_commons_license_type_options());
   $by_options = array();
   $by_options['allow_derivatives'] = array_keys(xml_form_elements_creative_commons_derivative_options());
   $by_options['allow_commercial'] = array_keys(xml_form_elements_creative_commons_commercial_options());
   $by_options['license_jurisdiction'] = array_keys(xml_form_elements_creative_commons_jurisdiction_options());
-  // Check if queried license type exists, reset to 'none' otherwise.
-  if (!in_array($values['license_fieldset']['license_type'], $allowed_licenses)) {
-    $values['license_fieldset']['license_type'] = 'none';
+  // Check if queried license type exists, is a string and is allowed, reset to
+  // 'none' otherwise.
+  if (!isset($input['license_fieldset']['license_type']) ||
+    !is_string($input['license_fieldset']['license_type']) ||
+    !in_array($input['license_fieldset']['license_type'], $allowed_licenses)) {
+    $input['license_fieldset']['license_type'] = 'none';
   }
   // Clean up selected 'by' options.
-  if ($values['license_fieldset']['license_type'] != 'by') {
+  if ($input['license_fieldset']['license_type'] != 'by') {
     // Reset derivative, commercial and jurisdiction options when not 'by'.
     foreach ($by_options as $key => $opts) {
-      $values['license_fieldset'][$key] = $opts[0];
+      $input['license_fieldset'][$key] = $opts[0];
     }
   }
   else {
-    // Check if all selected options exist, reset them otherwise.
+    // Check if all selected options exist, are strings and allowed, reset them
+    // otherwise.
     foreach ($by_options as $key => $opts) {
-      if (!in_array($values['license_fieldset'][$key], $opts)) {
-        $values['license_fieldset'][$key] = $opts[0];
+      if (!isset($input['license_fieldset'][$key]) ||
+        !is_string($input['license_fieldset'][$key]) ||
+        !in_array($input['license_fieldset'][$key], $opts)) {
+        $input['license_fieldset'][$key] = $opts[0];
       }
     }
   }
+  // If version override is integer, make it a string.
+  if (isset($input['license_fieldset']['override_license_version']) &&
+    is_int($input['license_fieldset']['override_license_version'])) {
+    $input['license_fieldset']['override_license_version'] = (string) $input['license_fieldset']['override_license_version'];
+  }
+  // Clean up version override.
+  if (!isset($input['license_fieldset']['override_license_version']) ||
+    !is_string($input['license_fieldset']['override_license_version']) ||
+    !in_array($input['license_fieldset']['override_license_version'], array('0', '1')) ||
+    in_array($input['license_fieldset']['license_type'], array('none', 'manual'))) {
+    $input['license_fieldset']['override_license_version'] = '0';
+  }
   // Clean up version.
-  if (in_array($values['license_fieldset']['license_type'], array('none', 'manual'))) {
-    $values['license_fieldset']['license_version'] = '';
+  if (!isset($input['license_fieldset']['license_version']) ||
+    !is_string($input['license_fieldset']['license_version']) ||
+    ($input['license_fieldset']['override_license_version'] != '1') ||
+    in_array($input['license_fieldset']['license_type'], array('none', 'manual'))) {
+    $input['license_fieldset']['license_version'] = '';
   }
-  // Nuke license URI if not in manual mode.
-  if ($values['license_fieldset']['license_type'] != 'manual') {
-    $values['license_fieldset']['license_uri'] = '';
+  // Empty license URI if unset, not a string or not in manual mode.
+  if (!isset($input['license_fieldset']['license_uri']) ||
+    !is_string($input['license_fieldset']['license_uri']) ||
+    ($input['license_fieldset']['license_type'] != 'manual')) {
+    $input['license_fieldset']['license_uri'] = '';
   }
-  // Return cleaned-up user values.
-  return $values;
+  // Return cleaned-up user input.
+  return $input;
 }
 
 /**
@@ -557,8 +653,8 @@ function xml_form_elements_creative_commons_get_values_from_uri($license_uri) {
   $supported_licenses = array_diff(array_keys(xml_form_elements_creative_commons_license_type_options()), array('none', 'manual'));
 
   // Make a default array based on the URI.
-  $values = xml_form_elements_creative_commons_cleanup_values(
-    xml_form_elements_creative_commons_make_value_array('manual', '', '', '', '', $license_uri)
+  $values = xml_form_elements_creative_commons_cleanup_input(
+    xml_form_elements_creative_commons_make_value_array('manual', '', '', '', '0', '', $license_uri)
   );
 
   // If no license URI is set, default to no output.
@@ -572,15 +668,15 @@ function xml_form_elements_creative_commons_get_values_from_uri($license_uri) {
     $uri_value_array = array_reverse(explode('/',
       preg_replace('#^' . XML_FORM_ELEMENTS_CREATIVE_COMMONS_BASE_URL . '#', '', $license_uri)
     ));
-    // Remove the license path.
-    array_pop($uri_value_array);
+    // Get the license path.
+    $path = array_pop($uri_value_array);
     // Get license with properties.
     $properties = explode('-', array_pop($uri_value_array));
-    // If the license is supported, set the type.
-    if (in_array($properties[0], $supported_licenses)) {
+    // If the license is supported and has correct path, set the type.
+    if (in_array($properties[0], $supported_licenses) && (xml_form_elements_creative_commons_get_license_path($properties[0]) === $path)) {
       $values['license_fieldset']['license_type'] = $properties[0];
     }
-    // Parse 'by' options.
+    // Parse 'by' options; otherwise reset to manual if those options exist.
     if ($properties[0] == 'by') {
       foreach ($properties as $property) {
         switch ($property) {
@@ -601,6 +697,11 @@ function xml_form_elements_creative_commons_get_values_from_uri($license_uri) {
         }
       }
     }
+    elseif (count($properties) != 1) {
+      $values['license_fieldset']['license_type'] = 'manual';
+    }
+    // Since we do not know if version is newest, we set version overriding.
+    $values['license_fieldset']['override_license_version'] = '1';
     // Get version.
     $values['license_fieldset']['license_version'] = array_pop($uri_value_array);
     // Get jurisdiction.
@@ -685,43 +786,75 @@ function xml_form_elements_creative_commons_get_uri_from_values($values) {
 }
 
 /**
- * Process input and get values for `creative_commons` form element.
+ * Get markup and values for `creative_commons` form element.
  *
  * @param array $element
  *   The `creative_commons` form element.
- * @param array|NULL $input
- *   The user input (or NULL to retrieve defaults).
  * @param array $form_state
  *   The form state.
  *
  * @return array
- *   The associative array representing the form element values.
- *
- * Note that validation for the `creative_commons` element is done whithin this
- * function. This has the side effect that users cannot go to the previous step
- * in a mulit-step form before resolving erroneous choices.
+ *   An array containing:
+ *   - the markup for the chosen license;
+ *   - the associative value array for that license.
  */
-function xml_form_elements_creative_commons_process_input(&$element, $input, &$form_state) {
-  // Get defaults from element, if available.
-  $default_values = xml_form_elements_creative_commons_get_values_from_uri(isset($element['#default_value']) ? $element['#default_value'] : '');
-  // Set initial values.
-  $values = !empty($input) ? xml_form_elements_creative_commons_cleanup_values($input) : $default_values;
-  // If no output was requested, return.
-  if ($values['license_fieldset']['license_type'] == 'none') {
-    return $values;
+function xml_form_elements_creative_commons_get_processed_values(&$element, &$form_state) {
+  // Get current form values or defaults.
+  $values = isset($form_state['input'][$element['#name']]) ?
+    xml_form_elements_creative_commons_cleanup_input(is_string($form_state['values'][$element['#name']]) ?
+      xml_form_elements_creative_commons_get_values_from_uri($form_state['values'][$element['#name']]) :
+      $form_state['values'][$element['#name']]) :
+    xml_form_elements_creative_commons_get_values_from_uri(isset($element['#default_value']) ?
+      $element['#default_value'] :
+      '');
+
+  // Set prefix for license HTML markup.
+  $cc_prefix = '<strong>' . t('Selected license:') . '</strong> ';
+
+  // Define none markup.
+  $none = t('None.');
+
+  // Create empty values.
+  $empty_values = xml_form_elements_creative_commons_get_values_from_uri('');
+
+  // If some values are missing, return filled-up value array.
+  if (!isset($values['license_fieldset']) || !empty(array_diff_key($empty_values['license_fieldset'], $values['license_fieldset']))) {
+    $values['license_fieldset'] = array_merge($empty_values['license_fieldset'], isset($values['license_fieldset']) ? $values['license_fieldset'] : array());
+    drupal_set_message(t('An internal error occurred while processing the Creative Commons form element "@display_name" (unexpected data loss). Please inform the site administrator.', array("@display_name" => $element['license_fieldset']['#title'])), 'error');
+    watchdog('xml_form_elements', 'Unexpected data loss when processing element "@element_name" in "@form_name". Probably you just found a bug.', array('@element_name' => $element['#name'], '@form_name' => $form_state['storage'][FormStorage::STORAGE_ROOT]['name']), WATCHDOG_ERROR);
+    return array($cc_prefix . t('None (internal error).'), $values);
   }
-  // If in manual mode, try to guess the license, but reset to manual.
-  if ($values['license_fieldset']['license_type'] == 'manual') {
+
+  // Remember manual mode.
+  $manual = ($values['license_fieldset']['license_type'] == 'manual');
+
+  // If in manual mode, try to guess the license.
+  if ($manual) {
     $values = xml_form_elements_creative_commons_get_values_from_uri($values['license_fieldset']['license_uri']);
-    $values['license_fieldset']['license_type'] = 'manual';
   }
-  // If in manual mode with no license URI set, return.
-  if ($values['license_fieldset']['license_type'] == 'manual' && empty($values['license_fieldset']['license_uri'])) {
-    return $values;
+
+  // If in manual mode with no license URI set, set to empty.
+  if ($manual && empty($values['license_fieldset']['license_uri'])) {
+    $values = $empty_values;
+  }
+
+  // If no output was requested, return empty.
+  if ($values['license_fieldset']['license_type'] == 'none') {
+    // If in manual mode, re-set mode.
+    if ($manual) {
+      $empty_values['license_fieldset']['license_type'] = 'manual';
+    }
+    return array($cc_prefix . $none, $empty_values);
   }
 
   // Know if we have errors.
   $error = FALSE;
+
+  // Define the element for version errors.
+  $error_element = $element['#name'] . ($manual ? '][license_fieldset][license_uri' : '][license_fieldset][license_version');
+
+  // Define none with form errors markup.
+  $none_err = t('None (form has errors).');
 
   // Validate the initial version.
   if (!xml_form_elements_creative_commons_license_version_has_valid_format($values['license_fieldset']['license_version'])) {
@@ -741,18 +874,37 @@ function xml_form_elements_creative_commons_process_input(&$element, $input, &$f
     }
   }
 
-  // If there was an error, return.
+  // If there was an error, return current values.
   if ($error) {
-    return $values;
+    // If in manual mode, re-set mode.
+    if ($manual) {
+      $values['license_fieldset']['license_type'] = 'manual';
+    }
+    return array($cc_prefix . $none_err, $values);
   }
 
-  // Check if there is a newer version unless user sets the URI manually.
-  if (!in_array($values['license_fieldset']['license_type'], array('none', 'manual'))) {
-    // Prepare the API query (keep only what's needed).
-    $current_query = $values;
-    $current_query['license_fieldset']['license_version'] = '';
-    $current_query['license_fieldset']['license_uri'] = '';
-    $response = xml_form_elements_creative_commons_retrieve_api_response($element['#name'], 'api_data_get', $current_query, $form_state);
+  // Remember if _user_ wants to override version.
+  $override_version = isset($form_state['input'][$element['#name']]) &&
+    ((bool) ((int) $values['license_fieldset']['override_license_version']));
+
+  // If not in (pure) manual mode (i.e. we know the license), get the newest.
+  if ($values['license_fieldset']['license_type'] != 'manual') {
+    // Get the appropriate API path for the requested license type.
+    $api_path = xml_form_elements_creative_commons_get_api_path($values['license_fieldset']['license_type']);
+    // Default to standard for unknown licenses.
+    if (!$api_path) {
+      $api_path = 'license/standard/get';
+    }
+    // Prepare query options.
+    $api_options = array();
+    if ($values['license_fieldset']['license_type'] == 'by') {
+      $api_options = array(
+        'commercial' => $values['license_fieldset']['allow_commercial'],
+        'derivatives' => $values['license_fieldset']['allow_derivatives'],
+        'jurisdiction' => $values['license_fieldset']['license_jurisdiction'],
+      );
+    }
+    $response = xml_form_elements_creative_commons_query_api_get($api_path, $api_options);
     if ($response && $response->getName() != 'error') {
       // Get the newest license URI and get its version.
       $new_license_uri = (string) $response->{'license-uri'};
@@ -760,24 +912,22 @@ function xml_form_elements_creative_commons_process_input(&$element, $input, &$f
       $new_version = $new_values['license_fieldset']['license_version'];
       // Get current version.
       $version = $values['license_fieldset']['license_version'];
-      // Check version validity, if specified.
-      if ($version != '' && (float) $new_version != (float) $version) {
+      // Check version validity, if overriding.
+      if (($values['license_fieldset']['override_license_version'] == '1') && $version != '' && ((float) $new_version != (float) $version)) {
         // Update the target license URI's version.
         $new_license_uri = str_replace($new_version, $version, $new_license_uri);
         // Compare versions.
         if ((float) $new_version < (float) $version) {
           // The specified version is too high.
           $error = TRUE;
-          form_set_error($element['#name'] . '][license_fieldset][license_version', t("CC license version not (yet) available."));
+          form_set_error($error_element, t("CC license version not (yet) available."));
         }
       }
       else {
         // We queried the newest version, or the specified version is already
-        // the newest. We make sure the version is empty for the next request.
-        $values['license_fieldset']['license_version'] = '';
-        // Manually update cache for output.
-        $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $new_license_uri);
-        xml_form_elements_creative_commons_store_api_response($element['#name'], 'api_data', $current_query, $response, $form_state);
+        // the newest. We update the version and switch to non-overriding.
+        $values['license_fieldset']['license_version'] = $new_version;
+        $values['license_fieldset']['override_license_version'] = '0';
       }
     }
     else {
@@ -790,19 +940,36 @@ function xml_form_elements_creative_commons_process_input(&$element, $input, &$f
       }
       $new_license_uri = xml_form_elements_creative_commons_get_uri_from_values($values);
     }
-    // Store the new license URI.
-    $values['license_fieldset']['license_uri'] = $new_license_uri;
+    // If we had already a URI in manual mode and it differs from the new one,
+    // reset to manual now; otherwise store the new license URI.
+    if ($manual && (!empty($values['license_fieldset']['license_uri']) && $values['license_fieldset']['license_uri'] !== $new_license_uri)) {
+      $values['license_fieldset']['license_type'] = 'manual';
+    }
+    else {
+      $values['license_fieldset']['license_uri'] = $new_license_uri;
+    }
+    // Reset version overriding in automatic mode, if _user_ requested it.
+    if (!$manual && $override_version) {
+      $values['license_fieldset']['override_license_version'] = '1';
+    }
   }
 
-  // If there was an error, return.
+  // If there was an error, return current values.
   if ($error) {
-    return $values;
+    // If in manual mode, re-set mode.
+    if ($manual) {
+      $values['license_fieldset']['license_type'] = 'manual';
+    }
+    return array($cc_prefix . $none_err, $values);
   }
 
-  // Check the URI we are about to return.
-  if (!empty($values['license_fieldset']['license_uri'])) {
-    $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $values['license_fieldset']['license_uri']);
-    $response = xml_form_elements_creative_commons_retrieve_api_response($element['#name'], 'api_data', $current_query, $form_state);
+  // If in manual mode, or if the previous request was unsuccessful, or if a
+  // different version was specified, query the API for validation for
+  // non-empty URIs.
+  if ((($values['license_fieldset']['license_type'] == 'manual') || !isset($new_version) || ($version != '' && ((float) $version != (float) $new_version)))
+    && !empty($values['license_fieldset']['license_uri'])) {
+    // Get the license details for the specified license URI.
+    $response = xml_form_elements_creative_commons_query_api_details($values['license_fieldset']['license_uri']);
     if ($response) {
       if ($response->getName() == 'error') {
         // The license URI is not recognized.
@@ -811,7 +978,7 @@ function xml_form_elements_creative_commons_process_input(&$element, $input, &$f
           form_set_error($element['#name'] . '][license_fieldset][license_uri', t("CC license URI seems to be invalid. Perhaps you would prefer to choose one automatically?"));
         }
         else {
-          form_set_error($element['#name'] . '][license_fieldset][license_version', t("CC license version does not seem to exist."));
+          form_set_error($error_element, t("CC license version does not seem to exist."));
         }
       }
     }
@@ -821,8 +988,47 @@ function xml_form_elements_creative_commons_process_input(&$element, $input, &$f
     }
   }
 
-  // Return the values for the form element.
-  return $values;
+  // If there was an error, return current values.
+  if ($error) {
+    // If in manual mode, re-set mode.
+    if ($manual) {
+      $values['license_fieldset']['license_type'] = 'manual';
+    }
+    return array($cc_prefix . $none_err, $values);
+  }
+
+  // Prepare the license markup.
+  $cc_markup = $none;
+  // If the license URI is set (as expected), get the API markup.
+  if (!empty($values['license_fieldset']['license_uri'])) {
+    if (!$response) {
+      $cc_markup = t('"@uri" (manually generated since Creative Commons API could not be reached).', array('@uri' => $values['license_fieldset']['license_uri']));
+    }
+    elseif ($response->getName() == 'error') {
+      // We should never be here.
+      drupal_set_message(t('An unexpected error occurred with the Creative Commons form element "@display_name". Please inform the site administrator.', array('@display_name' => $element['license_fieldset']['#title'])), 'error');
+      watchdog('xml_form_elements', 'The Creative Commons API returned an error on "@uri" that should have been cought already. This happened while processing element "@element_name" in "@form_name". Probably you just found a bug.', array(
+        '@uri' => $element['license_fieldset']['license_uri'],
+        '@element_name' => $element['#name'],
+        '@form_name' => $form_state['storage'][FormStorage::STORAGE_ROOT]['name'],
+      ), WATCHDOG_ERROR);
+    }
+    else {
+      // Get the HTML markup for the selected license.
+      $cc_markup = $response->html->asXml();
+      // Mend bogus <html> tags.
+      $cc_markup = preg_replace('#^<html>#', '<div>', $cc_markup);
+      $cc_markup = preg_replace('#</html>$#', '</div>', $cc_markup);
+    }
+  }
+
+  // If in manual mode, re-set mode.
+  if ($manual) {
+    $values['license_fieldset']['license_type'] = 'manual';
+  }
+
+  // Return current values.
+  return array($cc_prefix . $cc_markup, $values);
 }
 
 /**
@@ -880,12 +1086,7 @@ function xml_form_elements_creative_commons_get_api_path($license) {
  * insert those licenses manually, and admins cannot set them as default.
  */
 function xml_form_elements_creative_commons_query_api_get($path, $options = array()) {
-  $response = drupal_http_request(url(XML_FORM_ELEMENTS_CREATIVE_COMMONS_API_URL . $path, array('query' => $options)));
-  if ($response->code != 200) {
-    watchdog('xml_form_elements', 'The Creative Commons API responded with code %code.', array('%code' => $response->code), WATCHDOG_WARNING);
-    return FALSE;
-  }
-  return simplexml_load_string($response->data, 'SimpleXMLElement');
+  return _xml_form_elements_creative_commons_query_api($path, $options);
 }
 
 /**
@@ -899,89 +1100,28 @@ function xml_form_elements_creative_commons_query_api_get($path, $options = arra
  *   failed.
  */
 function xml_form_elements_creative_commons_query_api_details($license_uri) {
-  $response = drupal_http_request(url(XML_FORM_ELEMENTS_CREATIVE_COMMONS_API_URL . 'details', array('query' => array('license-uri' => $license_uri))));
+  return _xml_form_elements_creative_commons_query_api('details', array('license-uri' => $license_uri));
+}
+
+/**
+ * Helper function to query the CC API.
+ *
+ * @param string $path
+ *   The API path to query.
+ * @param array $query
+ *   The query.
+ *
+ * @return SimpleXMLElement|FALSE
+ *   The response from the REST API as a SimpleXMLElement, or FALSE if request
+ *   failed.
+ */
+function _xml_form_elements_creative_commons_query_api($path, $query = array()) {
+  $response = drupal_http_request(url(XML_FORM_ELEMENTS_CREATIVE_COMMONS_API_URL . $path, array('query' => $query)));
   if ($response->code != 200) {
     watchdog('xml_form_elements', 'The Creative Commons API responded with code %code.', array('%code' => $response->code), WATCHDOG_WARNING);
     return FALSE;
   }
   return simplexml_load_string($response->data, 'SimpleXMLElement');
-}
-
-/**
- * Store an API response in storage.
- *
- * @param string $element_name
- *   The `creative_commons` element's name.
- * @param string $storage_folder
- *   The storage "subfolder".
- * @param array $values
- *   The associative value array that was used in the query
- *   (@see xml_form_elements_creative_commons_make_value_array())
- * @param SimpleXMLElement $response
- *   The API response.
- * @param array $form_state
- *   The form state.
- */
-function xml_form_elements_creative_commons_store_api_response($element_name, $storage_folder, $values, $response, &$form_state) {
-  if (!isset($form_state['storage']['xml_form_elements'][$element_name][$storage_folder])) {
-    $form_state['storage']['xml_form_elements'][$element_name][$storage_folder] = array();
-  }
-  $form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['query'] = $values;
-  $form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['response'] = ($response !== FALSE) ? $response->asXML() : FALSE;
-}
-
-/**
- * Perform API request and cache in storage.
- *
- * @param string $element_name
- *   The `creative_commons` element's name.
- * @param string $storage_folder
- *   The storage "subfolder".
- * @param array $values
- *   The associative value array to use in the query
- *   (@see xml_form_elements_creative_commons_make_value_array()).
- * @param array $form_state
- *   The form state.
- *
- * @return mixed
- *   SimpleXMLElement the return from the REST API.
- *   FALSE if failed request.
- */
-function xml_form_elements_creative_commons_retrieve_api_response($element_name, $storage_folder, $values, &$form_state) {
-  if (isset($form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['query']) &&
-    $form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['query'] == $values &&
-    isset($form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['response']) &&
-    ($form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['response'] !== FALSE)) {
-    // Get response from storage.
-    $response = simplexml_load_string($form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['response'], 'SimpleXMLElement');
-  }
-  else {
-    if (empty($values['license_fieldset']['license_uri'])) {
-      // Without specified URI, get a fresh license based on input values.
-      $api_path = xml_form_elements_creative_commons_get_api_path($values['license_fieldset']['license_type']);
-      // Default to standard for unknown licenses.
-      if (!$api_path) {
-        $api_path = 'license/standard/get';
-      }
-      // Prepare query options.
-      $api_options = array();
-      if ($values['license_fieldset']['license_type'] == 'by') {
-        $api_options = array(
-          'commercial' => $values['license_fieldset']['allow_commercial'],
-          'derivatives' => $values['license_fieldset']['allow_derivatives'],
-          'jurisdiction' => $values['license_fieldset']['license_jurisdiction'],
-        );
-      }
-      $response = xml_form_elements_creative_commons_query_api_get($api_path, $api_options);
-    }
-    else {
-      // Get the license details for the specified license URI.
-      $response = xml_form_elements_creative_commons_query_api_details($values['license_fieldset']['license_uri']);
-    }
-    // Cache response.
-    xml_form_elements_creative_commons_store_api_response($element_name, $storage_folder, $values, $response, $form_state);
-  }
-  return $response;
 }
 
 /**

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -178,7 +178,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   $element['license_fieldset']['license_type'] = array(
     '#type' => 'select',
     '#title' => t('Select a license type'),
-    '#description' => t('Select "@option" to avoid outputting a creative commons license. This will still output a blank element in the resulting XML, so make sure to use a cleanup template to remove it.', array('@option' => $license_options['none'])),
+    '#description' => t('Select "@option" to avoid outputting a creative commons license.', array('@option' => $license_options['none'])),
     '#empty_option' => $license_options['none'],
     '#empty_value' => 'none',
     '#options' => array_diff_key($license_options, array('none' => '')),
@@ -394,9 +394,9 @@ function _xml_form_elements_creative_commons_populate_element(&$element, &$form_
     $element['license_fieldset']['license_uri']['#required'] = ($values['license_fieldset']['license_type'] == 'manual');
   }
 
-  // Nuke the description of the type chooser when none was chosen.
+  // Replace the description of the type chooser when none was chosen.
   if ($element['license_fieldset']['license_type']['#value'] == 'none') {
-    unset($element['license_fieldset']['license_type']['#description']);
+    $element['license_fieldset']['license_type']['#description'] = t('Note that your selection will still output a blank element in the resulting XML, so make sure to use a cleanup template to remove it.');
   }
 }
 

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -238,22 +238,7 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   if ($values['license_fieldset']['license_type'] != 'none' && !empty($values['license_fieldset']['license_uri'])) {
     // Get data from storage.
     $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $values['license_fieldset']['license_uri']);
-    if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query']) &&
-      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] == $current_query &&
-      isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response']) &&
-      ($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] !== FALSE)) {
-      // Get response from storage.
-      $response = simplexml_load_string($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'], 'SimpleXMLElement');
-    }
-    else {
-      $response = xml_form_elements_get_creative_commons_from_uri($values['license_fieldset']['license_uri']);
-      // Cache response.
-      if (!isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data'])) {
-        $form_state['storage']['xml_form_elements'][$element['#name']]['api_data'] = array();
-      }
-      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] = $current_query;
-      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] = ($response !== FALSE) ? $response->asXML() : FALSE;
-    }
+    $response = xml_form_elements_creative_commons_get_api_response($element['#name'], 'api_data', $current_query, $form_state);
     if ($response) {
       if ($response->getName() == 'error') {
         $cc_markup = t('None (form has errors).');
@@ -284,7 +269,6 @@ function xml_form_elements_creative_commons($element, &$form_state) {
   $element['license_fieldset']['license_update'] = array(
     '#type' => 'button',
     '#value' => t('Update license'),
-    '#weight' => 10,
     '#limit_validation_errors' => array(),
     '#submit' => array('xml_form_elements_creative_commons_license_update_submit'),
     '#return_value' => 'update-license',
@@ -401,23 +385,7 @@ function xml_form_elements_creative_commons_get_value_array_from_input(&$element
   if (!in_array($license, array('none', 'manual'))) {
     // Check if there is a newer version unless user sets the URI manually.
     $current_query = xml_form_elements_creative_commons_make_value_array($license, $derivatives, $commercial, $jurisdiction, '', '');
-    $response = FALSE;
-    if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['query']) &&
-      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['query'] == $current_query &&
-      isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['response']) &&
-      ($form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['response'] !== FALSE)) {
-      // Get response from storage.
-      $response = simplexml_load_string($form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['response'], 'SimpleXMLElement');
-    }
-    else {
-      $response = xml_form_elements_get_creative_commons($commercial, $derivatives, $jurisdiction, FALSE, '', $license);
-      // Cache response.
-      if (!isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get'])) {
-        $form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get'] = array();
-      }
-      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['query'] = $current_query;
-      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data_get']['response'] = ($response !== FALSE) ? $response->asXML() : FALSE;
-    }
+    $response = xml_form_elements_creative_commons_get_api_response($element['#name'], 'api_data_get', $current_query, $form_state);
     if ($response) {
       $license_uri = (string) $response->{'license-uri'};
       $license_value_array = xml_form_elements_creative_commons_parse_uri($license_uri);
@@ -440,22 +408,7 @@ function xml_form_elements_creative_commons_get_value_array_from_input(&$element
             watchdog('xml_form_elements', 'Creative Commons default license seems to be deprecated. Please announce the developers.', array(), WATCHDOG_WARNING);
           }
           $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $license_uri);
-          if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query']) &&
-            $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] == $current_query &&
-            isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response']) &&
-            ($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] !== FALSE)) {
-            // Get response from storage.
-            $response = simplexml_load_string($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'], 'SimpleXMLElement');
-          }
-          else {
-            $response = xml_form_elements_get_creative_commons_from_uri($license_uri);
-            // Cache response.
-            if (!isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data'])) {
-              $form_state['storage']['xml_form_elements'][$element['#name']]['api_data'] = array();
-            }
-            $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] = $current_query;
-            $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] = ($response !== FALSE) ? $response->asXML() : FALSE;
-          }
+          $response = xml_form_elements_creative_commons_get_api_response($element['#name'], 'api_data', $current_query, $form_state);
           if ($response) {
             if ($response->getName() == 'error') {
               // The license URI is not recognized.
@@ -471,11 +424,7 @@ function xml_form_elements_creative_commons_get_value_array_from_input(&$element
       else {
         // Manually update cache for output.
         $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $license_uri);
-        if (!isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data'])) {
-          $form_state['storage']['xml_form_elements'][$element['#name']]['api_data'] = array();
-        }
-        $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] = $current_query;
-        $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] = ($response !== FALSE) ? $response->asXML() : FALSE;
+        xml_form_elements_creative_commons_store_api_response($element['#name'], 'api_data', $current_query, $response, $form_state);
       }
     }
     else {
@@ -487,25 +436,10 @@ function xml_form_elements_creative_commons_get_value_array_from_input(&$element
   elseif ($license == 'manual' && $license_uri != '') {
     // Check manually entered license URI.
     $current_query = xml_form_elements_creative_commons_make_value_array('', '', '', '', '', $license_uri);
-    if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query']) &&
-      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] == $current_query &&
-      isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response']) &&
-      ($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] !== FALSE)) {
-      // Get response from storage.
-      $response = simplexml_load_string($form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'], 'SimpleXMLElement');
-    }
-    else {
-      $response = xml_form_elements_get_creative_commons_from_uri($license_uri);
-      // Cache response.
-      if (!isset($form_state['storage']['xml_form_elements'][$element['#name']]['api_data'])) {
-        $form_state['storage']['xml_form_elements'][$element['#name']]['api_data'] = array();
-      }
-      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['query'] = $current_query;
-      $form_state['storage']['xml_form_elements'][$element['#name']]['api_data']['response'] = ($response !== FALSE) ? $response->asXML() : FALSE;
-    }
+    $response = xml_form_elements_creative_commons_get_api_response($element['#name'], 'api_data', $current_query, $form_state);
     if ($response) {
-      // The license URI is not recognized.
       if ($response->getName() == 'error') {
+        // The license URI is not recognized.
         $error = TRUE;
         form_set_error($element['#name'] . '][license_fieldset][license_uri', t("CC license URI seems to be invalid. Perhaps you would prefer to choose one automatically?"));
       }
@@ -514,6 +448,12 @@ function xml_form_elements_creative_commons_get_value_array_from_input(&$element
       // We could not reach the API.
       drupal_set_message(t("Warning: Could not reach Creative Commons API to validate your input."));
     }
+  }
+  // In no error occurred, we reset all the variables based on the URI,
+  // except for the license type.
+  if (!$error && $license_uri != '') {
+    list($new_license, $commercial, $derivatives, $version, $jurisdiction) = xml_form_elements_creative_commons_parse_uri($license_uri);
+    unset($new_license);
   }
   // Force values into $form_state['input']
   $form_state['input'][$element['#name']] = xml_form_elements_creative_commons_make_value_array($license, $derivatives, $commercial, $jurisdiction, $version, $license_uri);
@@ -620,7 +560,7 @@ function xml_form_elements_creative_commons_get_license_path($license) {
  *   - The license ('zero', 'mark', 'by' or 'sampling+')
  *   - Commercial use ('y', 'n'; 'y' if license not 'by')
  *   - Derivative creation ('y', 'n', 'sa'; 'y' if license not 'by')
- *   - Jurisdiction (empty string if international or not applicable)
+ *   - Jurisdiction ('international' if international or not applicable)
  *   - Version
  */
 function xml_form_elements_creative_commons_parse_uri($license_uri) {
@@ -660,6 +600,9 @@ function xml_form_elements_creative_commons_parse_uri($license_uri) {
   $version = array_pop($default_value_array);
 
   $jurisdiction = array_pop($default_value_array);
+  if (empty($jurisdiction)) {
+    $jurisdiction = 'international';
+  }
 
   return array($license, $commercial, $derivatives, $version, $jurisdiction);
 }
@@ -681,6 +624,67 @@ function xml_form_elements_creative_commons_ajax(&$form, &$form_state) {
   $creative_commons_element = drupal_array_get_nested_value($form, $parents);
 
   return $creative_commons_element;
+}
+
+/**
+ * Store an API response in storage.
+ *
+ * @param string $element_name
+ *   The `creative_commons` element's name.
+ * @param string $storage_folder
+ *   The storage "subfolder".
+ * @param array $values
+ *   The associative value array that was used in the query
+ *   (@see xml_form_elements_creative_commons_make_value_array())
+ * @param SimpleXMLElement $response
+ *   The API response.
+ * @param array $form_state
+ *   The form state.
+ */
+function xml_form_elements_creative_commons_store_api_response($element_name, $storage_folder, $values, $response, &$form_state) {
+  if (!isset($form_state['storage']['xml_form_elements'][$element_name][$storage_folder])) {
+    $form_state['storage']['xml_form_elements'][$element_name][$storage_folder] = array();
+  }
+  $form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['query'] = $values;
+  $form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['response'] = ($response !== FALSE) ? $response->asXML() : FALSE;
+}
+
+/**
+ * Perform API request and cache in storage.
+ *
+ * @param string $element_name
+ *   The `creative_commons` element's name.
+ * @param string $storage_folder
+ *   The storage "subfolder".
+ * @param array $values
+ *   The associative value array to use in the query
+ *   (@see xml_form_elements_creative_commons_make_value_array()).
+ * @param array $form_state
+ *   The form state.
+ *
+ * @return mixed
+ *   SimpleXMLElement the return from the REST API.
+ *   FALSE if failed request.
+ */
+function xml_form_elements_creative_commons_get_api_response($element_name, $storage_folder, $values, &$form_state) {
+  if (isset($form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['query']) &&
+    $form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['query'] == $values &&
+    isset($form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['response']) &&
+    ($form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['response'] !== FALSE)) {
+    // Get response from storage.
+    $response = simplexml_load_string($form_state['storage']['xml_form_elements'][$element_name][$storage_folder]['response'], 'SimpleXMLElement');
+  }
+  else {
+    if (!empty($values['license_fieldset']['license_uri'])) {
+      $response = xml_form_elements_get_creative_commons_from_uri($values['license_fieldset']['license_uri'], FALSE);
+    }
+    else {
+      $response = xml_form_elements_get_creative_commons($values['license_fieldset']['allow_commercial'], $values['license_fieldset']['allow_modifications'], $values['license_fieldset']['license_jurisdiction'], FALSE, $values['license_fieldset']['license_version'], $values['license_fieldset']['license_type']);
+    }
+    // Cache response.
+    xml_form_elements_creative_commons_store_api_response($element_name, $storage_folder, $values, $response, $form_state);
+  }
+  return $response;
 }
 
 /**

--- a/elements/includes/creative_commons.inc
+++ b/elements/includes/creative_commons.inc
@@ -818,7 +818,8 @@ function xml_form_elements_creative_commons_get_processed_values(&$element, &$fo
   $empty_values = xml_form_elements_creative_commons_get_values_from_uri('');
 
   // If some values are missing, return filled-up value array.
-  if (!isset($values['license_fieldset']) || !empty(array_diff_key($empty_values['license_fieldset'], $values['license_fieldset']))) {
+  $missing_values = array_diff_key($empty_values['license_fieldset'], $values['license_fieldset']);
+  if (!isset($values['license_fieldset']) || !empty($missing_values)) {
     $values['license_fieldset'] = array_merge($empty_values['license_fieldset'], isset($values['license_fieldset']) ? $values['license_fieldset'] : array());
     drupal_set_message(t('An internal error occurred while processing the Creative Commons form element "@display_name" (unexpected data loss). Please inform the site administrator.', array("@display_name" => $element['license_fieldset']['#title'])), 'error');
     watchdog('xml_form_elements', 'Unexpected data loss when processing element "@element_name" in "@form_name". Probably you just found a bug.', array('@element_name' => $element['#name'], '@form_name' => $form_state['storage'][FormStorage::STORAGE_ROOT]['name']), WATCHDOG_ERROR);

--- a/elements/js/creative_commons.js
+++ b/elements/js/creative_commons.js
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * Prevent page submit while Creative Commons AJAX is still processing.
+ */
+
+(function($) {
+  Drupal.behaviors.xmlFormElementCreativeCommons = {
+    attach: function (context, settings) {
+      $('[id|=license-fieldset]', context).parents('form').once(function(){
+        // Get form id.
+        var $id = this.id;
+        // When AJAX starts, disable the submit buttons.
+        $(document).ajaxStart(function(){
+          // Disable all submit elements.
+          $('#' + $id + ' .form-submit').attr('disabled', 'disabled');
+        });
+        // When AJAX completes, re-enable the submit buttons.
+        $(document).ajaxComplete(function(){
+          // Re-enable all submit elements.
+          $('#' + $id + ' .form-submit').removeAttr('disabled');
+        });
+      });
+    }
+  }
+})(jQuery);

--- a/elements/xml_form_elements.module
+++ b/elements/xml_form_elements.module
@@ -82,7 +82,6 @@ function xml_form_elements_element_info() {
       '#input' => TRUE,
       '#tree' => FALSE,
       '#process' => array('xml_form_elements_creative_commons_process'),
-      '#value_callback' => 'xml_form_elements_creative_commons_value_callback',
     ),
     // Designed for the form builder UI please do not use programmatically.
     'indent' => array(
@@ -590,10 +589,7 @@ function xml_form_elements_defaultable_markup($children, &$elements) {
 }
 
 /**
- * Process for the creative_commons_process form element.
- *
- * The state of #tree is managed by this form element because #tree is needed
- * for ajax but destroys the value_callback.
+ * Process for the `creative_commons` form element.
  *
  * @param array $element
  *   The element to create.
@@ -608,37 +604,4 @@ function xml_form_elements_defaultable_markup($children, &$elements) {
 function xml_form_elements_creative_commons_process($element, &$form_state, $complete_form) {
   form_load_include($form_state, 'inc', 'xml_form_elements', 'includes/creative_commons');
   return xml_form_elements_creative_commons($element, $form_state);
-}
-
-/**
- * Value callback for creative commons element.
- *
- * Input isn't set in form builder edits. Data from the process function can't
- * be relied on to be available in value callbacks because Drupal caches before
- * the element is processed.
- *
- * @param array $element
- *   The element.
- * @param array $input
- *   The input of the element.
- * @param array $form_state
- *   The form state.
- *
- * @return string
- *   The license URI.
- */
-function xml_form_elements_creative_commons_value_callback(&$element, $input, &$form_state) {
-  form_load_include($form_state, 'inc', 'xml_form_elements', 'includes/creative_commons');
-  if (isset($input) && $input && current_path() != 'system/ajax') {
-    if (isset($form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'])) {
-      return $form_state['storage']['xml_form_elements'][$element['#name']]['license_uri'];
-    }
-    else {
-      extract($input['license_fieldset']);
-      if (!isset($disabled)) {
-        $disabled = FALSE;
-      }
-      return xml_form_elements_creative_commons_value($allow_commercial, $allow_modifications, $license_jurisdiction, $disabled);
-    }
-  }
 }


### PR DESCRIPTION
Also, implement ISLANDORA-2208 and solve issues in #251

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2205

* https://jira.duraspace.org/browse/ISLANDORA-2208
* #251

# What does this Pull Request do?

Re-design `creative_commons` element to solve bugs and implement new features. In particular, users can set default license in form builder, choose Public Domain licenses, override license versions and work without JS.

# What's new?

* Honour '#default_value'
* Allow CC0 & Public Domain Mark licenses
* Graceful non-JS degradation
* Allow overriding license version
* Allow setting license URI manually
* Validate versions, resp. license URIs
* Cache last query to API for speed-up
* Fix `<html>` wrapper of API response
* Renounce to value callback; populate values in element creation function
* Remove '#tree' logic in favour of manipulating `$form_state` directly

# How should this be tested?

* On a test VM, try to reproduce all the issues listed in the JIRA tickets and the above-mentioned PR.
* Pull this PR
* Verify that issues have disappeared (and no new ones arose).

# Additional Notes:

Since this PR basically re-designs the `creative_commons` element (in particular dropping the '#tree' manipulation), it could well be that
1. This code is more buggy than the previous one
2. There are neater ways of doing what is done here

A thorough code review is, therefore, indispensable.

Example:
* Does this change require documentation to be updated? **perhaps?**
* Does this change add any new dependencies?  **no**
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? **probably not, as functions only got extended by optional arguments**
* Could this change impact execution of existing code? **hopefully not**

# Interested parties
@adam-vessey @bondjimbond @rosiel @whikloj @DiegoPino @Islandora/7-x-1-x-committers
