### PR TITLE
ISLANDORA-877: Prevent visible empty `div` for `datepicker` element

### DIFF
--- a/elements/theme/ui.datepicker.css
+++ b/elements/theme/ui.datepicker.css
@@ -1,6 +1,6 @@
 /* Datepicker
 ----------------------------------*/
-.ui-datepicker { width: 17em; padding: .2em .2em 0; }
+.ui-datepicker { width: 17em; padding: .2em .2em 0; display: none; }
 .ui-datepicker .ui-datepicker-header { position:relative; padding:.2em 0; }
 .ui-datepicker .ui-datepicker-prev, .ui-datepicker .ui-datepicker-next { position:absolute; top: 2px; width: 1.8em; height: 1.8em; }
 .ui-datepicker .ui-datepicker-prev-hover, .ui-datepicker .ui-datepicker-next-hover { top: 1px; }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-877

# What does this Pull Request do?

Prevent visible empty `<div>` at bottom of page for forms with `datepicker` element.

# What's new?

Add `display: none;` to `datepicker` CSS to hide it on page load.

# How should this be tested?

* View a metadata form that includes a `datepicker` element
* Notice an _empty, yet visible_ `<div>` at the bottom left corner of the page (see also screenshot in [ISLANDORA-877](https://jira.duraspace.org/browse/ISLANDORA-877))
* Pull this PR and empty (browser) caches
* Reload the form without the visual hiccup

# Additional Notes:
It is possible that this is more of a problem in jQuery and should, therefore, be addressed upstream. Meanwhile, the present PR can serve as a temporary solution.

* Does this change require documentation to be updated? *no*
* Does this change add any new dependencies? *no*
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? *no*
* Could this change impact execution of existing code? *no*

# Interested parties
@willtp87 @rosiel @DiegoPino @Islandora/7-x-1-x-committers
