### PR TITLE
ISLANDORA-1402: URL Raw encode URL-breaking characters in form names

### DIFF
--- a/builder/Copy.inc
+++ b/builder/Copy.inc
@@ -55,7 +55,8 @@ function xml_form_builder_copy($form, array &$form_state, $form_name) {
 /**
  * Validates the name Drupal Form Element.
  *
- * Ensures that the name doesn't match any existing form names.
+ * Ensures that the name does not match any existing form names and that it
+ * does not contain troublesome characters.
  *
  * @param array $element
  *   The name Drupal Form Element.
@@ -65,6 +66,17 @@ function xml_form_builder_copy($form, array &$form_state, $form_name) {
 function xml_form_builder_copy_validate_name(array $element, array &$form_state) {
   module_load_include('inc', 'xml_form_builder', 'XMLFormRepository');
   $form_name = &$form_state['values']['form_name'];
+  $forbidden_chars = array('/', '#', '?');
+  foreach ($forbidden_chars as $char) {
+    if (strpos($form_name, $char) !== FALSE) {
+      $error_msg = t('The given form name "%name" is not allowed to contain any of the following characters: "@charlist".', array(
+        '%name' => $form_name,
+        '@charlist' => implode('", "', $forbidden_chars),
+      ));
+      form_set_error('form_name', $error_msg);
+      break;
+    }
+  }
   if (XMLFormRepository::Exists($form_name)) {
     $error_msg = t('The given form name "%name" is already in use. Form names must be unique.', array('%name' => $form_name));
     form_set_error('form_name', $error_msg);

--- a/builder/Copy.inc
+++ b/builder/Copy.inc
@@ -13,13 +13,14 @@
  * @param array $form_state
  *   The Drupal Form State.
  * @param string $form_name
- *   The name of the form to copy.
+ *   The name of the form to copy (rawurlencoded).
  *
  * @return array
  *   The Drupal Form.
  */
 function xml_form_builder_copy($form, array &$form_state, $form_name) {
   module_load_include('inc', 'xml_form_builder', 'XMLFormRepository');
+  $form_name = rawurldecode($form_name);
   if (isset($_POST['cancel'])) {
     drupal_goto(XML_FORM_BUILDER_MAIN_MENU);
   }
@@ -55,8 +56,7 @@ function xml_form_builder_copy($form, array &$form_state, $form_name) {
 /**
  * Validates the name Drupal Form Element.
  *
- * Ensures that the name does not match any existing form names and that it
- * does not contain troublesome characters.
+ * Ensures that the name does not match any existing form names.
  *
  * @param array $element
  *   The name Drupal Form Element.
@@ -66,17 +66,6 @@ function xml_form_builder_copy($form, array &$form_state, $form_name) {
 function xml_form_builder_copy_validate_name(array $element, array &$form_state) {
   module_load_include('inc', 'xml_form_builder', 'XMLFormRepository');
   $form_name = &$form_state['values']['form_name'];
-  $forbidden_chars = array('/', '#', '?');
-  foreach ($forbidden_chars as $char) {
-    if (strpos($form_name, $char) !== FALSE) {
-      $error_msg = t('The given form name "%name" is not allowed to contain any of the following characters: "@charlist".', array(
-        '%name' => $form_name,
-        '@charlist' => implode('", "', $forbidden_chars),
-      ));
-      form_set_error('form_name', $error_msg);
-      break;
-    }
-  }
   if (XMLFormRepository::Exists($form_name)) {
     $error_msg = t('The given form name "%name" is already in use. Form names must be unique.', array('%name' => $form_name));
     form_set_error('form_name', $error_msg);

--- a/builder/Create.inc
+++ b/builder/Create.inc
@@ -63,7 +63,8 @@ function xml_form_builder_create($form, array &$form_state, $type) {
 /**
  * Validates the name Drupal Form Element.
  *
- * Ensures that the name doesn't match any existing form names.
+ * Ensures that the name does not match any existing form names and that it
+ * does not contain troublesome characters.
  *
  * @param array $element
  *   The name Drupal Form Element.
@@ -73,6 +74,17 @@ function xml_form_builder_create($form, array &$form_state, $type) {
 function xml_form_builder_create_validate_name(array $element, array &$form_state) {
   module_load_include('inc', 'xml_form_builder', 'XMLFormRepository');
   $form_name = &$form_state['values']['form_name'];
+  $forbidden_chars = array('/', '#', '?');
+  foreach ($forbidden_chars as $char) {
+    if (strpos($form_name, $char) !== FALSE) {
+      $error_msg = t('The given form name "%name" is not allowed to contain any of the following characters: "@charlist".', array(
+        '%name' => $form_name,
+        '@charlist' => implode('", "', $forbidden_chars),
+      ));
+      form_set_error('form_name', $error_msg);
+      break;
+    }
+  }
   if (XMLFormRepository::Exists($form_name)) {
     $error_msg = t('The given form name "%name" is already in use. Form names must be unique.', array('%name' => $form_name));
     form_set_error('form_name', $error_msg);

--- a/builder/Create.inc
+++ b/builder/Create.inc
@@ -63,8 +63,7 @@ function xml_form_builder_create($form, array &$form_state, $type) {
 /**
  * Validates the name Drupal Form Element.
  *
- * Ensures that the name does not match any existing form names and that it
- * does not contain troublesome characters.
+ * Ensures that the name does not match any existing form names.
  *
  * @param array $element
  *   The name Drupal Form Element.
@@ -74,17 +73,6 @@ function xml_form_builder_create($form, array &$form_state, $type) {
 function xml_form_builder_create_validate_name(array $element, array &$form_state) {
   module_load_include('inc', 'xml_form_builder', 'XMLFormRepository');
   $form_name = &$form_state['values']['form_name'];
-  $forbidden_chars = array('/', '#', '?');
-  foreach ($forbidden_chars as $char) {
-    if (strpos($form_name, $char) !== FALSE) {
-      $error_msg = t('The given form name "%name" is not allowed to contain any of the following characters: "@charlist".', array(
-        '%name' => $form_name,
-        '@charlist' => implode('", "', $forbidden_chars),
-      ));
-      form_set_error('form_name', $error_msg);
-      break;
-    }
-  }
   if (XMLFormRepository::Exists($form_name)) {
     $error_msg = t('The given form name "%name" is already in use. Form names must be unique.', array('%name' => $form_name));
     form_set_error('form_name', $error_msg);

--- a/builder/Delete.inc
+++ b/builder/Delete.inc
@@ -13,13 +13,14 @@
  * @param array $form_state
  *   The Drupal Form State.
  * @param string $form_name
- *   The name of the form to delete.
+ *   The name of the form to delete (rawurlencoded).
  *
  * @return array
  *   The Drupal Form.
  */
 function xml_form_builder_delete($form, array &$form_state, $form_name) {
   module_load_include('inc', 'xml_form_builder', 'XMLFormDatabase');
+  $form_name = rawurldecode($form_name);
   if (!XMLFormDatabase::Exists($form_name)) {
     drupal_set_message(t('Form "%name" does not exist.', array('%name' => $form_name)), 'error');
     drupal_not_found();

--- a/builder/Edit.inc
+++ b/builder/Edit.inc
@@ -11,7 +11,7 @@
  * Includes all the required CSS/JS files needed to render the Form Builder GUI.
  *
  * @param string $form_name
- *   The name of the form to edit.
+ *   The name of the form to edit (rawurlencoded).
  *
  * @return string
  *   The html where the Form Builder GUI will be rendered.
@@ -19,6 +19,7 @@
 function xml_form_builder_edit($form_name) {
   module_load_include('inc', 'xml_form_builder', 'XMLFormDatabase');
 
+  $form_name = rawurldecode($form_name);
   if (!XMLFormDatabase::Exists($form_name)) {
     drupal_set_message(t('Form "%name" does not exist.', array('%name' => $form_name)), 'error');
     drupal_not_found();
@@ -87,7 +88,7 @@ function xml_form_builder_edit_include_js() {
  * the database as an XML Form Definition.
  *
  * @param string $form_name
- *   The name of the form to update.
+ *   The name of the form to update (rawurlencoded).
  *
  * @throws Exception
  *   If unable to instantiate the JSON form definition, or generate the XML form
@@ -97,6 +98,7 @@ function xml_form_builder_edit_save($form_name) {
   module_load_include('inc', 'xml_form_builder', 'JSONFormDefinition');
   module_load_include('inc', 'xml_form_builder', 'XMLFormDatabase');
   module_load_include('inc', 'xml_form_api', 'XMLFormDefinition');
+  $form_name = rawurldecode($form_name);
   try {
     // @TODO: this data needs to be sanitized. Can we get this data through the
     // form API?

--- a/builder/Preview.inc
+++ b/builder/Preview.inc
@@ -16,13 +16,14 @@
  * @param array $form_state
  *   The Drupal Form State.
  * @param string $form_name
- *   The name of the form to preview.
+ *   The name of the form to preview (rawurlencoded).
  *
  * @return array
  *   A Drupal Form that represents the given form, identified by $form_name.
  */
 function xml_form_builder_preview(array $form, array &$form_state, $form_name) {
   form_load_include($form_state, 'inc', 'xml_form_builder', 'Preview');
+  $form_name = rawurldecode($form_name);
   $form = xml_form_builder_get_form($form, $form_state, $form_name);
   $breadcrumb[] = l(t('Home'), '<front>');
   $breadcrumb[] = l(t('Islandora Admin'), 'admin/islandora');

--- a/builder/includes/associations.form.inc
+++ b/builder/includes/associations.form.inc
@@ -20,7 +20,7 @@
  * @param array $form_state
  *   The drupal form state.
  * @param string $form_name
- *   The name of an XML form.
+ *   The name of an XML form (rawurlencoded).
  *
  * @return array
  *   The drupal form definition.
@@ -29,6 +29,11 @@ function xml_form_builder_associations_form(array $form, array &$form_state, $fo
   module_load_include('inc', 'xml_form_builder', 'includes/associations');
   form_load_include($form_state, 'inc', 'xml_form_builder', 'includes/associations.form');
 
+  $form_name = rawurldecode($form_name);
+  $breadcrumb[] = l(t('Home'), '<front>');
+  $breadcrumb[] = l(t('Islandora Admin'), 'admin/islandora');
+  $breadcrumb[] = l(t('Form Builder'), 'admin/islandora/xmlform');
+  drupal_set_breadcrumb($breadcrumb);
   $associations = xml_form_builder_get_associations(array($form_name), array(), array(), FALSE);
   $create_table_rows = function ($association) {
     if (is_array($association['title_field'])) {
@@ -205,8 +210,8 @@ function xml_form_builder_get_title_options($form_name) {
  * provided by a hook.
  *
  * @param string $form_name
- *   The name of the form for which the associations are being adjusted.
- *   (used to redirect).
+ *   The name of the form for which the associations are being adjusted
+ *   (rawurlencoded; used to redirect).
  * @param string|int $id
  *   The identifier for the form association.  A string for "default" forms
  *   (added in via associations), and an integer for associations added via
@@ -214,6 +219,7 @@ function xml_form_builder_get_title_options($form_name) {
  */
 function xml_form_builder_disable_association($form_name, $id) {
   module_load_include('inc', 'xml_form_builder', 'includes/associations');
+  $form_name = rawurldecode($form_name);
   $association = xml_form_builder_get_association($id);
   if (!isset($association)) {
     drupal_set_message(t('Specified association does not exist.'), 'error');
@@ -261,8 +267,8 @@ function xml_form_builder_disable_association($form_name, $id) {
  * Enable a default association identified by $id.
  *
  * @param string $form_name
- *   The name of the form for which the associations are being adjusted.
- *   (used to redirect).
+ *   The name of the form for which the associations are being adjusted
+ *   (rawurlencoded; used to redirect).
  * @param string $id
  *   The identifier for the form association. Note that only "default"
  *   associations added via hook_xml_form_builder_form_associations() can be
@@ -270,6 +276,7 @@ function xml_form_builder_disable_association($form_name, $id) {
  */
 function xml_form_builder_enable_association($form_name, $id) {
   module_load_include('inc', 'xml_form_builder', 'includes/associations');
+  $form_name = rawurldecode($form_name);
   $association = xml_form_builder_get_association($id);
   if (!isset($association)) {
     drupal_set_message(t('Specified association does not exist.'), 'error');
@@ -311,7 +318,7 @@ function xml_form_builder_enable_association($form_name, $id) {
  * @param array $form_state
  *   The drupal form state.
  * @param string $form_name
- *   The name of an XML form.
+ *   The name of an XML form (rawurlencoded).
  * @param string $id
  *   The id of this association.
  *
@@ -320,6 +327,7 @@ function xml_form_builder_enable_association($form_name, $id) {
  */
 function xml_form_builder_edit_association_form(array $form, array &$form_state, $form_name, $id) {
   module_load_include('inc', 'xml_form_builder', 'includes/associations');
+  $form_name = rawurldecode($form_name);
   $association = xml_form_builder_get_association($id);
   $options = xml_form_builder_get_title_options($form_name);
   if (is_array($association['title_field'])) {

--- a/builder/xml_form_builder.module
+++ b/builder/xml_form_builder.module
@@ -195,8 +195,8 @@ function xml_form_builder_menu() {
     'type' => MENU_CALLBACK,
   );
   $items[XML_FORM_BUILDER_ASSOCIATIONS_MENU] = array(
-    'title' => 'Associate Form "@form"',
-    'title arguments' => array('@form' => 4),
+    'title arguments' => array(4),
+    'title callback' => '_xml_form_builder_associations_menu_title_callback',
     'description' => 'Associate a form.',
     'file' => 'includes/associations.form.inc',
     'page callback' => 'drupal_get_form',
@@ -250,6 +250,16 @@ function xml_form_builder_menu() {
   );
   return $items;
 }
+
+/**
+ * Title callback for associations menu.
+ *
+ * @param string $name
+ *   The form name (rawurlencoded).
+ */
+function _xml_form_builder_associations_menu_title_callback($name) {
+  return t('Associate Form "@form"', array('@form' => rawurldecode($name)));
+};
 
 /**
  * Implements hook_menu_alter().
@@ -345,10 +355,11 @@ function xml_form_builder_permission() {
  * Downloads the XML Form Definition to the clients computer..
  *
  * @param string $form_name
- *   The name of the form to download.
+ *   The name of the form to download (rawurlencoded).
  */
 function xml_form_builder_export($form_name) {
   module_load_include('inc', 'xml_form_builder', 'XMLFormRepository');
+  $form_name = rawurldecode($form_name);
   header('Content-Type: text/xml', TRUE);
   header('Content-Disposition: attachment; filename="' . $form_name . '.xml"');
   $definition = XMLFormRepository::Get($form_name);
@@ -361,12 +372,13 @@ function xml_form_builder_export($form_name) {
  * Gets the path to the copy page for the given form name.
  *
  * @param string $form_name
- *   The form to load the copy page with.
+ *   The form to load the copy page with (rawurlencoded).
  *
  * @return string
  *   The path to the copy page.
  */
 function xml_form_builder_get_copy_form_path($form_name) {
+  $form_name = rawurlencode($form_name);
   return str_replace('%', $form_name, XML_FORM_BUILDER_COPY_MENU);
 }
 
@@ -374,12 +386,13 @@ function xml_form_builder_get_copy_form_path($form_name) {
  * Gets the path to the edit page for the given form name.
  *
  * @param string $form_name
- *   The form to load the edit page with.
+ *   The form to load the edit page with (rawurlencoded).
  *
  * @return string
  *   The path to the edit page.
  */
 function xml_form_builder_get_edit_form_path($form_name) {
+  $form_name = rawurlencode($form_name);
   return str_replace('%', $form_name, XML_FORM_BUILDER_EDIT_MENU);
 }
 
@@ -387,12 +400,13 @@ function xml_form_builder_get_edit_form_path($form_name) {
  * Gets the path to the view page for the given form name.
  *
  * @param string $form_name
- *   The form to load the view page with.
+ *   The form to load the view page with (rawurlencoded).
  *
  * @return string
  *   The path to the view page.
  */
 function xml_form_builder_get_view_form_path($form_name) {
+  $form_name = rawurlencode($form_name);
   return str_replace('%', $form_name, XML_FORM_BUILDER_VIEW_MENU);
 }
 
@@ -400,12 +414,13 @@ function xml_form_builder_get_view_form_path($form_name) {
  * Gets the path to the delete page for the given form name.
  *
  * @param string $form_name
- *   The form to load the delete page with.
+ *   The form to load the delete page with (rawurlencoded).
  *
  * @return string
  *   The path to the delete page.
  */
 function xml_form_builder_get_export_form_path($form_name) {
+  $form_name = rawurlencode($form_name);
   return str_replace('%', $form_name, XML_FORM_BUILDER_EXPORT_CALLBACK);
 }
 
@@ -413,12 +428,13 @@ function xml_form_builder_get_export_form_path($form_name) {
  * Gets the path to the delete page for the given form name.
  *
  * @param string $form_name
- *   The form to load the delete page with.
+ *   The form to load the delete page with (rawurlencoded).
  *
  * @return string
  *   The path to the delete page.
  */
 function xml_form_builder_get_delete_form_path($form_name) {
+  $form_name = rawurlencode($form_name);
   return str_replace('%', $form_name, XML_FORM_BUILDER_DELETE_MENU);
 }
 
@@ -426,12 +442,13 @@ function xml_form_builder_get_delete_form_path($form_name) {
  * Gets the path to the associations page for the given form name.
  *
  * @param string $form_name
- *   The form to load the associations page with.
+ *   The form to load the associations page with (rawurlencoded).
  *
  * @return string
  *   The path to the associations page.
  */
 function xml_form_builder_get_associate_form_path($form_name) {
+  $form_name = rawurlencode($form_name);
   return str_replace('%', $form_name, XML_FORM_BUILDER_ASSOCIATIONS_MENU);
 }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1402

* https://jira.duraspace.org/browse/ISLANDORA-1192 (original of the above duplicate; closed on 2018-05-25 for de-duplication)

# Note [introduced in edit]

The title of this PR
> ISLANDORA-1402: Forbid URL-breaking characters in form names as a temporary solution

should now read
> ISLANDORA-1402: Encode form names in URLs

# What does this Pull Request do?

[edit]

~Forbid '/', '#' and '?' in form names for newly created forms.~

Encode form names in URLs so that problematic characters (chiefly '`/`', '`#`' and, perhaps, even '`?`') do not break form accessibility (_Copy_/_Edit_/_View_/_Export_/_Delete_/_Associate_ links on `/admin/islandora/xmlform/forms`).

# What's new?

[edit]

~Add logic inside name validator function to throw form error when the submitted form name contains one of the aforementioned characters.~

`rawurlencode()` form names in displayed links and `rawurldecode()` form names in page callbacks.

# How should this be tested?

[edit]

On a test VM:

* ~Go to `http://localhost:8000/admin/islandora/xmlform/forms/create`~
* ~Introduce a form name that contains '`/`', '`#`' and/or '`?`'~
* ~Submit and (probably) find your form inaccessible, since the form name will be part of the URL for all tasks (copy, edit, view, export, delete, associate)~
* ~Try the same when copying a form (`http://localhost:18000/admin/islandora/xmlform/forms/YOUR_FORM_NAME/copy`)~
* ~Pull this PR and repeat~
* ~Confirm that you cannot create or copy a form giving it a name containing any of the aforementioned characters~

* Create, copy, view, export, delete and associate forms with any names and confirm that
    * form names are always encoded in the URLs
    * form names are displayed un-encoded
    * no hiccup occurs

# Additional Notes:

[edit]

~This is just a _temporary_ solution to [ISLANDORA-1402](https://jira.duraspace.org/browse/ISLANDORA-1402). Ultimately, we wish to modify the way form names are stored (probably giving them machine names that will serve as URL parts, while retaining full names for display).~

~Also note that we make no attempt here to "revive" forms that were created with problematic names. These can be considered lost for the time being.~

This PR modifies a few functions. In particular, the page callbacks of `xml_form_builder` now expect `rawurlencode()`d form names as parameter. This has the potential to break outside code that recycles those functions.

* Does this change require documentation to be updated? **probably not**
* Does this change add any new dependencies? **no**
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? **no**
* Could this change impact execution of existing code? ~**no**~ **possibly**

# Interested parties
@dmoses @bondjimbond @willtp87 @adam-vessey @DiegoPino @Islandora/7-x-1-x-committers
