### PR TITLE
ISLANDORA-897: Add scrolling to More Advanced Controls

### DIFF
--- a/builder/js/ElementForm.js
+++ b/builder/js/ElementForm.js
@@ -1217,6 +1217,7 @@ Ext.formbuilder.createElementForm = function () {
         items: [{
           xtype: 'formgrid',
           id: 'attributes',
+          autoScroll: true,
           name: 'attributes',
           title: Drupal.t('Attributes'),
           store: Ext.create('Ext.data.Store', {
@@ -1267,6 +1268,7 @@ Ext.formbuilder.createElementForm = function () {
           xtype: 'formgrid',
           id: 'element_validate',
           name: 'element_validate',
+          autoScroll: true,
           title: Drupal.t('Element Validate'),
           store: Ext.create('Ext.data.Store', {
             fields:['value'],
@@ -1307,6 +1309,7 @@ Ext.formbuilder.createElementForm = function () {
           title: Drupal.t('Process'),
           id: 'process',
           name: 'process',
+          autoScroll: true,
           store: Ext.create('Ext.data.Store', {
             fields:['value'],
             proxy: {
@@ -1345,6 +1348,7 @@ Ext.formbuilder.createElementForm = function () {
           title: Drupal.t('Pre Render'),
           id: 'pre_render',
           name: 'pre_render',
+          autoScroll: true,
           store: Ext.create('Ext.data.Store', {
             fields:['value'],
             proxy: {
@@ -1388,6 +1392,7 @@ Ext.formbuilder.createElementForm = function () {
           title: Drupal.t('Post Render'),
           id: 'post_render',
           name: 'post_render',
+          autoScroll: true,
           store: Ext.create('Ext.data.Store', {
             fields:['value'],
             proxy: {
@@ -1431,6 +1436,7 @@ Ext.formbuilder.createElementForm = function () {
           title: Drupal.t('After Build'),
           id: 'after_build',
           name: 'after_build',
+          autoScroll: true,
           store: Ext.create('Ext.data.Store', {
             fields:['value'],
             proxy: {
@@ -1467,6 +1473,7 @@ Ext.formbuilder.createElementForm = function () {
         }, {
           xtype: 'formgrid',
           id: 'options',
+          autoScroll: true,
           name: 'options',
           title: Drupal.t('Options'),
           store: Ext.create('Ext.data.Store', {
@@ -1517,6 +1524,7 @@ Ext.formbuilder.createElementForm = function () {
           title: Drupal.t('User Data'),
           id: 'user_data',
           name: 'user_data',
+          autoScroll: true,
           store: Ext.create('Ext.data.Store', {
             fields:['key', 'value'],
             proxy: {
@@ -1565,6 +1573,7 @@ Ext.formbuilder.createElementForm = function () {
           title: Drupal.t('Submit'),
           id: 'submit',
           name: 'submit',
+          autoScroll: true,
           store: Ext.create('Ext.data.Store', {
             fields:['value'],
             proxy: {
@@ -1604,6 +1613,7 @@ Ext.formbuilder.createElementForm = function () {
           title: Drupal.t('Validate'),
           id: 'validate',
           name: 'validate',
+          autoScroll: true,
           store: Ext.create('Ext.data.Store', {
             fields:['value'],
             proxy: {


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-897)

# What does this Pull Request do?

Allows scrolling in the blocks within More Advanced Controls. 

# What's new?
If there are multiple values in a given window, enough to go beyond the bounds of the box, you could not scroll through them to see what's outside the bounds. Now you can, using the mouse's scrolling feature. This also solves a problem in Chrome where selecting lower-down items with the arrow keys would not result in the window scrolling.

# How should this be tested?

* Create a form element with a field type that requires values in More Advanced Controls, e.g. "select" type
* Under More Advanced Controls, put 8 to 10 different values in the Options box
* Try scrolling, note that it doesn't work
* Check out this branch -- scrolling is better!

# Additional Notes:
Scrolling still isn't perfect, but it's better than it was. Would love to add an actual scroll bar, but that doesn't seem to work, possibly due to other, earlier code or just the way it's built. This does the job at least.

# Interested parties
@d-r-p @DiegoPino  @Islandora/7-x-1-x-committers
