### PR TITLE
ISLANDORA-2342

### DIFF
--- a/builder/xml_form_builder.install
+++ b/builder/xml_form_builder.install
@@ -70,7 +70,7 @@ function xml_form_builder_schema() {
         'description' => 'An XSL transform for setting the Fedora object\'s Dublin Core metadata datastream.',
         'type' => 'varchar',
         'length' => 128,
-        'not null' => TRUE,
+        'not null' => FALSE,
       ),
       'self_transform' => array(
         'description' => 'A xsl transform for setting the Fedora Object\'s Dublin Core metadata datastream.',
@@ -522,14 +522,6 @@ function xml_form_builder_update_7106() {
       'not null' => TRUE,
     )
   );
-  db_change_field('xml_form_builder_form_associations', 'transform', 'transform',
-    array(
-      'description' => 'An XSL transform for setting the Fedora object\'s Dublin Core metadata datastream.',
-      'type' => 'varchar',
-      'length' => 128,
-      'not null' => TRUE,
-    )
-  );
   db_change_field('xml_form_builder_form_associations', 'template', 'template',
     array(
       'description' => 'A sample metadata file used to prepopulate the form on ingest.',
@@ -619,4 +611,20 @@ function xml_form_builder_update_7106() {
     db_add_primary_key('xml_form_builder_association_hooks', array('id'));
     db_add_primary_key('xml_form_builder_xslts', array('xslt_id'));
   }
+}
+
+/**
+ * Allow null in tranform field.
+ *
+ * Previous update was causing issues when the transform was allowed to be null.
+ */
+function xml_form_builder_update_7107() {
+  db_change_field('xml_form_builder_form_associations', 'transform', 'transform',
+    array(
+      'description' => 'An XSL transform for setting the Fedora object\'s Dublin Core metadata datastream.',
+      'type' => 'varchar',
+      'length' => 128,
+      'not null' => FALSE,
+    )
+  );
 }


### PR DESCRIPTION
## JIRA Ticket

https://jira.duraspace.org/browse/ISLANDORA-2342

## What does this Pull Request do?

Update hook 7106, in specific this line https://github.com/Islandora/islandora_xml_forms/blob/7.x/builder/xml_form_builder.install#L525 fails if there is an actual XML association with a NULL value for XSLT transform value.

## What's new?

Fix issue with previous update hook where we set the `transforms` column to not null that may contain null values. Instead of making this column not null we just allow this column to contains nulls.

This commit does three things:
  - Updates the schema to allow nulls in the `transforms` column
  - Fixes the bug in the update hook, so users shouldn't see the issue
  - Adds a new update hook to make sure the column is the same for everyone.

## How should this be tested?

I believe there are 3 scenarios that need testing here: 
1. The user hasn't updated and they have NULLs in the `transforms` column. 
2. A new install of the module, where the new schema is installed automatically. 
3. An install where there are no NULL in the `transforms` column and 7106 has applied successfully. 7107 should apply and allow the transforms column to contains NULLs. 

In each of these scenarios, need to make sure that the form association creations are working well after this patch is applied.

# Interested parties
@Islandora/7-x-1-x-committers @DiegoPino 