### PR TITLE
Sanitises the the values to open

### DIFF
--- a/api/XMLDocument.inc
+++ b/api/XMLDocument.inc
@@ -141,7 +141,7 @@ class XMLDocument {
     $document = $this->createDOMDocument();
     // Load from XML or create the root node.
     isset($xml) ?
-        $document->loadXML($xml) :
+        $document->loadXML(preg_replace('/[\x00-\x09\x0B\x0C\x0E-\x1F\x7F]/', '', $xml)) :
         $document->appendChild(new DOMElement($root_name, NULL, $namespaces->getDefaultURI()));
     $this->namespaces->addNamespacesAttributesTo($document->documentElement);
     return $document;

--- a/builder/includes/datastream.form.inc
+++ b/builder/includes/datastream.form.inc
@@ -155,6 +155,7 @@ function xml_form_builder_datastream_form_metadata_form(array $form, array &$for
   $form['update'] = array(
     '#type' => 'submit',
     '#value' => t('Update'),
+    '#suffix' => '<div class="updatewarning"><span class="warning" title="Warning">' . t('All hidden characters will be filtered and not saved.') . '</span></div>',
     '#name' => 'update',
     '#submit' => array('xml_form_builder_datastream_form_metadata_form_submit'),
   );


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/ISLANDORA-2498

# What does this Pull Request do?
XML forms will open a MODS file with non compliant characters when you try to edit the MODS file; causing a system error and stopping the process. 

This just sanitizes the XML values before they are piped to the browser.

# What's new?
Just the string replace code around the XML string.

# How should this be tested?
Using the test MODS in the ticket. Batch ingest it to bypass the form (avoiding the error) the try to edit. The error should show up. 

Apply patch and not more error.

# Additional Notes:
![Screen Shot 2020-01-17 at 8 18 07 AM](https://user-images.githubusercontent.com/2738244/72615146-fcf6ba80-3901-11ea-94d9-87b96cec1be2.png)

# Interested parties
@Islandora/7-x-1-x-committers
